### PR TITLE
Fix MDF editor parsing and node config UX issues

### DIFF
--- a/src/cdlgmdfmodule.cpp
+++ b/src/cdlgmdfmodule.cpp
@@ -81,6 +81,7 @@ CDlgMdfModule::CDlgMdfModule(QWidget* parent)
   connect(ui->btnEditInfo, &QToolButton::clicked, this, &CDlgMdfModule::editInfo);
   connect(ui->btnDupInfo, &QToolButton::clicked, this, &CDlgMdfModule::dupInfo);
   connect(ui->btnDelInfo, &QToolButton::clicked, this, &CDlgMdfModule::deleteInfo);
+  connect(ui->comboModuleLevel, qOverload<int>(&QComboBox::currentIndexChanged), this, [this](int) { updateBufferSizeLockForLevel(); });
 
   // Help
   QShortcut* shortcut_F1 = new QShortcut(QKeySequence(Qt::Key_F1), this, SLOT(showHelp()));
@@ -130,6 +131,7 @@ CDlgMdfModule::initDialogData(const CMDF_Object* pmdfobj, mdf_module_index index
     ui->editDate->setDate(date);
   }
   ui->editBufferSize->setValue(m_pmdf->getModuleBufferSize());
+  updateBufferSizeLockForLevel();
   ui->editCopyright->setText(m_pmdf->getModuleCopyright().c_str());
 
   switch (index) {
@@ -300,6 +302,7 @@ CDlgMdfModule::accept()
     str = ui->editDate->date().toString(Qt::ISODate).toStdString();
     m_pmdf->setModuleChangeDate(str);
 
+    updateBufferSizeLockForLevel();
     m_pmdf->setModuleBufferSize(ui->editBufferSize->value());
 
     str = ui->editCopyright->text().toStdString();
@@ -310,6 +313,24 @@ CDlgMdfModule::accept()
   }
 
   QDialog::accept();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// updateBufferSizeLockForLevel
+//
+
+void
+CDlgMdfModule::updateBufferSizeLockForLevel(void)
+{
+  // Combo index 0 corresponds to Level 1.
+  const bool isLevel1 = (0 == ui->comboModuleLevel->currentIndex());
+  if (isLevel1) {
+    ui->editBufferSize->setValue(8);
+    ui->editBufferSize->setEnabled(false);
+  }
+  else {
+    ui->editBufferSize->setEnabled(true);
+  }
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/cdlgmdfmodule.h
+++ b/src/cdlgmdfmodule.h
@@ -151,6 +151,7 @@ public:
 
 public slots:
   void accept(void);
+  void updateBufferSizeLockForLevel(void);
 
   // Description buttons
   void addDesc(void);

--- a/src/cdlgmdfregister.cpp
+++ b/src/cdlgmdfregister.cpp
@@ -36,6 +36,7 @@
 #include <vscpworks.h>
 
 #include "cdlgmdfregister.h"
+#include "cdlgmdfremotevar.h"
 #include "ui_cdlgmdfregister.h"
 
 #include <QColorDialog>
@@ -136,6 +137,11 @@ CDlgMdfRegister::initDialogData(CMDF* pmdf, CMDF_Register* preg, int index)
           this,
           SLOT(setUndef()));
 
+  connect(ui->toolButton_6,
+          SIGNAL(clicked()),
+          this,
+          SLOT(onRemoteVariableAction()));
+
   setName(preg->getName().c_str());
   setPage(preg->getPage());
   setOffset(preg->getOffset());
@@ -218,6 +224,16 @@ CDlgMdfRegister::initDialogData(CMDF* pmdf, CMDF_Register* preg, int index)
       ui->editName->setFocus();
       break;
   }
+
+  connect(ui->comboPage,
+          qOverload<int>(&QComboBox::currentIndexChanged),
+          this,
+          [this](int) { updateRemoteVariableLinkUi(); });
+  connect(ui->editOffset,
+          &QLineEdit::textChanged,
+          this,
+          [this](const QString&) { updateRemoteVariableLinkUi(); });
+  updateRemoteVariableLinkUi();
 
   this->setFixedSize(this->size());
 }
@@ -573,4 +589,110 @@ CDlgMdfRegister::showHelp(void)
 {
   QString link = "https://grodansparadis.github.io/vscp-works-qt/#/mdf";
   QDesktopServices::openUrl(QUrl(link));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// findLinkedRemoteVariable
+//
+
+CMDF_RemoteVariable*
+CDlgMdfRegister::findLinkedRemoteVariable(void)
+{
+  if (nullptr == m_pmdf) {
+    return nullptr;
+  }
+
+  const uint16_t page   = getPage();
+  const uint32_t offset = getOffset();
+  std::deque<CMDF_RemoteVariable*>* pRemoteVariables = m_pmdf->getRemoteVariableList();
+  if (nullptr == pRemoteVariables) {
+    return nullptr;
+  }
+
+  for (auto* pRemoteVariable : *pRemoteVariables) {
+    if (nullptr == pRemoteVariable) {
+      continue;
+    }
+
+    if (page != pRemoteVariable->getPage()) {
+      continue;
+    }
+
+    if ((offset >= pRemoteVariable->getOffset()) &&
+        (offset < (pRemoteVariable->getOffset() + pRemoteVariable->getTypeByteCount()))) {
+      return pRemoteVariable;
+    }
+  }
+
+  return nullptr;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// updateRemoteVariableLinkUi
+//
+
+void
+CDlgMdfRegister::updateRemoteVariableLinkUi(void)
+{
+  CMDF_RemoteVariable* pRemoteVariable = findLinkedRemoteVariable();
+  if (nullptr != pRemoteVariable) {
+    ui->labelRemoteVariable->setText(QString(tr("Remote variable %1")).arg(pRemoteVariable->getName().c_str()));
+    ui->toolButton_6->setText(tr("Edit..."));
+  }
+  else {
+    ui->labelRemoteVariable->setText(tr("Add remote variable"));
+    ui->toolButton_6->setText(tr("Add..."));
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// onRemoteVariableAction
+//
+
+void
+CDlgMdfRegister::onRemoteVariableAction(void)
+{
+  if (nullptr == m_pmdf) {
+    spdlog::error("MDF register information - Invalid MDF object (onRemoteVariableAction)");
+    return;
+  }
+
+  CMDF_RemoteVariable* pRemoteVariable = findLinkedRemoteVariable();
+  if (nullptr != pRemoteVariable) {
+    CDlgMdfRemoteVar dlg(this);
+    dlg.initDialogData(m_pmdf, pRemoteVariable, CDlgMdfRemoteVar::index_name);
+    dlg.exec();
+    updateRemoteVariableLinkUi();
+    return;
+  }
+
+  CMDF_RemoteVariable* pNewRemoteVariable = new CMDF_RemoteVariable();
+  if (nullptr == pNewRemoteVariable) {
+    spdlog::critical("Failed to allocate remote variable");
+    return;
+  }
+
+  const uint16_t page   = getPage();
+  const uint32_t offset = getOffset();
+  pNewRemoteVariable->setPage(page);
+  pNewRemoteVariable->setOffset(offset);
+  pNewRemoteVariable->setName(QString("remote_var_%1_%2").arg(page).arg(offset).toStdString());
+
+  CDlgMdfRemoteVar dlg(this);
+  dlg.initDialogData(m_pmdf, pNewRemoteVariable, CDlgMdfRemoteVar::index_name);
+  if (QDialog::Accepted == dlg.exec()) {
+    if (nullptr != findLinkedRemoteVariable()) {
+      QMessageBox::warning(this,
+                           tr(APPNAME),
+                           tr("A remote variable is already linked to this register."),
+                           QMessageBox::Ok);
+      delete pNewRemoteVariable;
+      return;
+    }
+    m_pmdf->getRemoteVariableList()->push_back(pNewRemoteVariable);
+    updateRemoteVariableLinkUi();
+  }
+  else {
+    delete pNewRemoteVariable;
+  }
 }

--- a/src/cdlgmdfregister.cpp
+++ b/src/cdlgmdfregister.cpp
@@ -53,6 +53,8 @@
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/spdlog.h>
 
+#include <algorithm>
+
 const char CDlgMdfRegister::pre_str_register[] = "Register: ";
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -602,8 +604,10 @@ CDlgMdfRegister::findLinkedRemoteVariable(void)
     return nullptr;
   }
 
-  const uint16_t page   = getPage();
-  const uint32_t offset = getOffset();
+  const uint16_t page         = getPage();
+  const uint32_t regStart     = getOffset();
+  const uint32_t regSpan      = (nullptr != m_preg) ? std::max<uint16_t>(1, m_preg->getSpan()) : 1;
+  const uint64_t regRangeEnd  = static_cast<uint64_t>(regStart) + static_cast<uint64_t>(regSpan);
   std::deque<CMDF_RemoteVariable*>* pRemoteVariables = m_pmdf->getRemoteVariableList();
   if (nullptr == pRemoteVariables) {
     return nullptr;
@@ -618,8 +622,12 @@ CDlgMdfRegister::findLinkedRemoteVariable(void)
       continue;
     }
 
-    if ((offset >= pRemoteVariable->getOffset()) &&
-        (offset < (pRemoteVariable->getOffset() + pRemoteVariable->getTypeByteCount()))) {
+    const uint64_t rvStart    = static_cast<uint64_t>(pRemoteVariable->getOffset());
+    const uint64_t rvSpan     = static_cast<uint64_t>(std::max<uint8_t>(1, pRemoteVariable->getTypeByteCount()));
+    const uint64_t rvRangeEnd = rvStart + rvSpan;
+
+    // Linked if register range and remote variable range overlap.
+    if ((static_cast<uint64_t>(regStart) < rvRangeEnd) && (rvStart < regRangeEnd)) {
       return pRemoteVariable;
     }
   }

--- a/src/cdlgmdfregister.cpp
+++ b/src/cdlgmdfregister.cpp
@@ -607,7 +607,7 @@ CDlgMdfRegister::findLinkedRemoteVariable(void)
   const uint16_t page         = getPage();
   const uint32_t regStart     = getOffset();
   const uint32_t regSpan      = (nullptr != m_preg) ? std::max<uint16_t>(1, m_preg->getSpan()) : 1;
-  const uint64_t regRangeEnd  = static_cast<uint64_t>(regStart) + static_cast<uint64_t>(regSpan);
+  const uint64_t regEnd       = static_cast<uint64_t>(regStart) + static_cast<uint64_t>(regSpan - 1);
   std::deque<CMDF_RemoteVariable*>* pRemoteVariables = m_pmdf->getRemoteVariableList();
   if (nullptr == pRemoteVariables) {
     return nullptr;
@@ -624,10 +624,8 @@ CDlgMdfRegister::findLinkedRemoteVariable(void)
 
     const uint64_t rvStart    = static_cast<uint64_t>(pRemoteVariable->getOffset());
     const uint64_t rvSpan     = static_cast<uint64_t>(std::max<uint8_t>(1, pRemoteVariable->getTypeByteCount()));
-    const uint64_t rvRangeEnd = rvStart + rvSpan;
-
-    // Linked if register range and remote variable range overlap.
-    if ((static_cast<uint64_t>(regStart) < rvRangeEnd) && (rvStart < regRangeEnd)) {
+    const uint64_t rvEnd      = rvStart + rvSpan;
+    if ((static_cast<uint64_t>(regStart) <= rvEnd) && (rvStart <= regEnd)) {
       return pRemoteVariable;
     }
   }

--- a/src/cdlgmdfregister.h
+++ b/src/cdlgmdfregister.h
@@ -165,7 +165,22 @@ public slots:
   /// Help
   void showHelp(void);
 
+  /*!
+    Open linked remote variable dialog or add a new one.
+  */
+  void onRemoteVariableAction(void);
+
 private:
+  /*!
+    Find remote variable linked to current register page/offset.
+  */
+  CMDF_RemoteVariable* findLinkedRemoteVariable(void);
+
+  /*!
+    Refresh remote variable link text/button state.
+  */
+  void updateRemoteVariableLinkUi(void);
+
   Ui::CDlgMdfRegister* ui;
 
   /// Register pages

--- a/src/cfrmmdf.cpp
+++ b/src/cfrmmdf.cpp
@@ -413,6 +413,7 @@ CFrmMdf::openMdfFromPath(const QString& path)
 
   m_last_path = path;
   m_labelOpenedFile->setText(tr("File: %1").arg(path));
+  addRecentSavedFile(path);
   loadMdf();
   m_bChanged = false;
 

--- a/src/cfrmmdf.cpp
+++ b/src/cfrmmdf.cpp
@@ -266,6 +266,21 @@ CFrmMdf::CFrmMdf(QWidget* parent, const char* path)
   ui->menuFile->insertSeparator(ui->actionClose);
   loadRecentSavedFiles();
 
+  QMenu* operationsMenu = new QMenu(tr("&Operations"), this);
+  QAction* actionShowOperations = operationsMenu->addAction(tr("Show operations for selected item"));
+  connect(actionShowOperations,
+          &QAction::triggered,
+          this,
+          [this]() {
+            QPoint menuPos = ui->treeMDF->viewport()->rect().center();
+            QTreeWidgetItem* selected = ui->treeMDF->currentItem();
+            if (nullptr != selected) {
+              menuPos = ui->treeMDF->visualItemRect(selected).center();
+            }
+            showMdfContextMenu(menuPos);
+          });
+  ui->menubar->insertMenu(ui->menuHelp->menuAction(), operationsMenu);
+
   // Open has been selected in the menu - Edit Module info
   connect(ui->actionEdit_item, SIGNAL(triggered()), this, SLOT(editItem()));
 

--- a/src/cfrmmdf.cpp
+++ b/src/cfrmmdf.cpp
@@ -266,21 +266,6 @@ CFrmMdf::CFrmMdf(QWidget* parent, const char* path)
   ui->menuFile->insertSeparator(ui->actionClose);
   loadRecentSavedFiles();
 
-  QMenu* operationsMenu = new QMenu(tr("&Operations"), this);
-  QAction* actionShowOperations = operationsMenu->addAction(tr("Show operations for selected item"));
-  connect(actionShowOperations,
-          &QAction::triggered,
-          this,
-          [this]() {
-            QPoint menuPos = ui->treeMDF->viewport()->rect().center();
-            QTreeWidgetItem* selected = ui->treeMDF->currentItem();
-            if (nullptr != selected) {
-              menuPos = ui->treeMDF->visualItemRect(selected).center();
-            }
-            showMdfContextMenu(menuPos);
-          });
-  ui->menubar->insertMenu(ui->menuHelp->menuAction(), operationsMenu);
-
   // Open has been selected in the menu - Edit Module info
   connect(ui->actionEdit_item, SIGNAL(triggered()), this, SLOT(editItem()));
 

--- a/src/cfrmnodeconfig.cpp
+++ b/src/cfrmnodeconfig.cpp
@@ -107,10 +107,10 @@ replaceAll(std::string text, const std::string& from, const std::string& to)
 static std::string
 normalizeBoldTags(const std::string& text)
 {
-  std::string rv = replaceAll(text, "<bold>", "<b>");
-  rv             = replaceAll(rv, "</bold>", "</b>");
-  rv             = replaceAll(rv, "<BOLD>", "<b>");
-  rv             = replaceAll(rv, "</BOLD>", "</b>");
+  std::string rv = replaceAll(text, "<bold>", "**");
+  rv             = replaceAll(rv, "</bold>", "**");
+  rv             = replaceAll(rv, "<BOLD>", "**");
+  rv             = replaceAll(rv, "</BOLD>", "**");
   return rv;
 }
 
@@ -4524,6 +4524,7 @@ CFrmNodeConfig::fillRemoteVariableHtmlInfo(QTreeWidgetItem* item, int column)
   }
   else {
     std::string desc = prv->getDescription();
+    desc = normalizeBoldTags(desc);
     html += m_mdf.format(desc);
   }
   html += "<p>";

--- a/src/cfrmnodeconfig.cpp
+++ b/src/cfrmnodeconfig.cpp
@@ -57,6 +57,7 @@
 
 #include "cdlgeditdm.h"
 #include "cdlgknownguid.h"
+#include "cdlgmdfremotevar.h"
 #include "cdlgtxtsearch.h"
 
 #include "cfrmnodeconfig.h"
@@ -207,11 +208,14 @@ CFrmNodeConfig::CFrmNodeConfig(QWidget* parent, json* pconn)
   // Setup register tab
   QHeaderView* treeViewHeaderRegisters = ui->treeWidgetRegisters->header();
   ui->treeWidgetRegisters->clear();
+  ui->treeWidgetRegisters->setColumnCount(REG_COL_COUNT);
+  ui->treeWidgetRegisters->setHeaderLabels({ tr("Page:Offset"), tr("Access"), tr("Value"), tr("Name"), tr("Remote variable") });
   ui->treeWidgetRegisters->setContextMenuPolicy(Qt::CustomContextMenu);
   ui->treeWidgetRegisters->setEditTriggers(QAbstractItemView::NoEditTriggers);
   ui->treeWidgetRegisters->setColumnWidth(REG_COL_POS, 200);
   ui->treeWidgetRegisters->setColumnWidth(REG_COL_ACCESS, 80);
-  ui->treeWidgetRegisters->setColumnWidth(REG_COL_POS, 160);
+  ui->treeWidgetRegisters->setColumnWidth(REG_COL_NAME, 220);
+  ui->treeWidgetRegisters->setColumnWidth(REG_COL_REMOTEVAR, 260);
 
   // Setup remote variable tab
   QHeaderView* treeViewHeaderRemoteVariables = ui->treeWidgetRemoteVariables->header();
@@ -1235,7 +1239,7 @@ CFrmNodeConfig::disableColors(bool bColors)
     for (int i = 0; i < m_StandardRegTopPage->childCount(); i++) {
       CRegisterWidgetItem* child =
         (CRegisterWidgetItem*)m_StandardRegTopPage->child(i);
-      for (int j = 0; j < 4; j++) {
+      for (int j = 0; j < REG_COL_COUNT; j++) {
         if (child->type() == TREE_LIST_REGISTER_TYPE) {
           // child->setForeground(j, child->parent()->foreground(j));
           child->setBackground(j, child->parent()->background(j));
@@ -1247,7 +1251,7 @@ CFrmNodeConfig::disableColors(bool bColors)
     for (int i = 0; i < m_StandardRegTopPage->childCount(); i++) {
       CRegisterWidgetItem* child =
         (CRegisterWidgetItem*)m_StandardRegTopPage->child(i);
-      for (int j = 0; j < 4; j++) {
+      for (int j = 0; j < REG_COL_COUNT; j++) {
         if (child->type() == TREE_LIST_REGISTER_TYPE) {
           // child->setForeground(j, QBrush(QColor("black")));
           child->setBackground(
@@ -3613,7 +3617,7 @@ CFrmNodeConfig::renderStandardRegisters(void)
       Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemNeverHasChildren;
 
     // Set foreground and background colors from MDF
-    for (int j = 0; j < 4; j++) {
+    for (int j = 0; j < REG_COL_COUNT; j++) {
       itemReg->setForeground(j, QBrush(QColor("black")));
       itemReg->setBackground(
         j,
@@ -3762,7 +3766,7 @@ CFrmNodeConfig::renderRegisters(void)
 
       // Set foreground and background colors from MDF
       if (!pworks->m_config_bDisableColors) {
-        for (int i = 0; i < 4; i++) {
+        for (int i = 0; i < REG_COL_COUNT; i++) {
           itemReg->setForeground(i, QBrush(QColor(pregmdf->getForegroundColor())));
           itemReg->setBackground(i, QBrush(QColor(pregmdf->getBackgroundColor())));
         }
@@ -3822,6 +3826,27 @@ CFrmNodeConfig::renderRegisters(void)
       itemReg->setText(REG_COL_NAME, pregmdf->getName().c_str());
       itemReg->setTextAlignment(REG_COL_NAME, Qt::AlignLeft);
       itemTopReg1->addChild(itemReg);
+
+      CMDF_RemoteVariable* pRemoteVariable = findRemoteVariableForRegister(itemReg->m_regOffset, itemReg->m_regPage);
+      QPushButton* pRemoteVarButton        = new QPushButton(ui->treeWidgetRegisters);
+      pRemoteVarButton->setAutoDefault(false);
+      pRemoteVarButton->setDefault(false);
+      pRemoteVarButton->setFocusPolicy(Qt::NoFocus);
+      if (nullptr != pRemoteVariable) {
+        pRemoteVarButton->setText(QString(tr("Remote variable %1")).arg(pRemoteVariable->getName().c_str()));
+        connect(pRemoteVarButton,
+                &QPushButton::clicked,
+                this,
+                [this, page = itemReg->m_regPage, offset = itemReg->m_regOffset]() { openRemoteVariableForRegister(offset, page); });
+      }
+      else {
+        pRemoteVarButton->setText(tr("Add remote variable"));
+        connect(pRemoteVarButton,
+                &QPushButton::clicked,
+                this,
+                [this, page = itemReg->m_regPage, offset = itemReg->m_regOffset]() { addRemoteVariableForRegister(offset, page); });
+      }
+      ui->treeWidgetRegisters->setItemWidget(itemReg, REG_COL_REMOTEVAR, pRemoteVarButton);
     }
   }
 
@@ -4170,6 +4195,112 @@ CFrmNodeConfig::updateChangeRemoteVariable(uint32_t offset, uint16_t page, bool 
       }
     }
     ++it;
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// findRemoteVariableForRegister
+//
+
+CMDF_RemoteVariable*
+CFrmNodeConfig::findRemoteVariableForRegister(uint32_t offset, uint16_t page)
+{
+  std::deque<CMDF_RemoteVariable*>* pRemoteVariableList = m_mdf.getRemoteVariableList();
+  if (nullptr == pRemoteVariableList) {
+    return nullptr;
+  }
+
+  for (auto* pRemoteVariable : *pRemoteVariableList) {
+    if (nullptr == pRemoteVariable) {
+      continue;
+    }
+
+    if (pRemoteVariable->getPage() != page) {
+      continue;
+    }
+
+    if ((offset >= pRemoteVariable->getOffset()) &&
+        (offset < (pRemoteVariable->getOffset() + pRemoteVariable->getTypeByteCount()))) {
+      return pRemoteVariable;
+    }
+  }
+
+  return nullptr;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// openRemoteVariableForRegister
+//
+
+void
+CFrmNodeConfig::openRemoteVariableForRegister(uint32_t offset, uint16_t page)
+{
+  CMDF_RemoteVariable* pRemoteVariable = findRemoteVariableForRegister(offset, page);
+  if (nullptr == pRemoteVariable) {
+    addRemoteVariableForRegister(offset, page);
+    return;
+  }
+
+  CDlgMdfRemoteVar dlg(this);
+  dlg.initDialogData(&m_mdf, pRemoteVariable);
+  dlg.setReadOnly();
+  if (QDialog::Accepted == dlg.exec()) {
+    renderRegisters();
+    renderRemoteVariables();
+  }
+
+  ui->session_tabWidget->setCurrentIndex(TAB_BAR_INDEX_REMOTEVARS);
+  for (int i = 0; i < ui->treeWidgetRemoteVariables->topLevelItemCount(); ++i) {
+    CRemoteVariableWidgetItem* item = (CRemoteVariableWidgetItem*)ui->treeWidgetRemoteVariables->topLevelItem(i);
+    if ((nullptr != item) && (item->m_pRemoteVariable == pRemoteVariable)) {
+      ui->treeWidgetRemoteVariables->setCurrentItem(item);
+      item->setSelected(true);
+      ui->treeWidgetRemoteVariables->scrollToItem(item, QAbstractItemView::PositionAtTop);
+      onRemoteVariableTreeWidgetItemClicked(item, REMOTEVAR_COL_NAME);
+      break;
+    }
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// addRemoteVariableForRegister
+//
+
+void
+CFrmNodeConfig::addRemoteVariableForRegister(uint32_t offset, uint16_t page)
+{
+  CMDF_RemoteVariable* pRemoteVariable = new CMDF_RemoteVariable();
+  if (nullptr == pRemoteVariable) {
+    spdlog::critical("Failed to allocate remote variable");
+    return;
+  }
+
+  pRemoteVariable->setPage(page);
+  pRemoteVariable->setOffset(offset);
+  pRemoteVariable->setName(QString("remote_var_%1_%2").arg(page).arg(offset).toStdString());
+
+  CDlgMdfRemoteVar dlg(this);
+  dlg.initDialogData(&m_mdf, pRemoteVariable, CDlgMdfRemoteVar::index_name);
+  if (QDialog::Accepted == dlg.exec()) {
+    CMDF_RemoteVariable* pExisting = m_mdf.getRemoteVariable(pRemoteVariable->getOffset(), pRemoteVariable->getPage());
+    if ((nullptr != pExisting) && (pExisting != pRemoteVariable)) {
+      QMessageBox::warning(this,
+                           tr(APPNAME),
+                           tr("Remote variable page=%1 offset=%2 is already defined.")
+                             .arg(pRemoteVariable->getPage())
+                             .arg(pRemoteVariable->getOffset()),
+                           QMessageBox::Ok);
+      delete pRemoteVariable;
+      return;
+    }
+
+    m_mdf.getRemoteVariableList()->push_back(pRemoteVariable);
+    renderRegisters();
+    renderRemoteVariables();
+    openRemoteVariableForRegister(offset, page);
+  }
+  else {
+    delete pRemoteVariable;
   }
 }
 

--- a/src/cfrmnodeconfig.cpp
+++ b/src/cfrmnodeconfig.cpp
@@ -107,10 +107,14 @@ replaceAll(std::string text, const std::string& from, const std::string& to)
 static std::string
 normalizeBoldTags(const std::string& text)
 {
-  std::string rv = replaceAll(text, "<bold>", "**");
-  rv             = replaceAll(rv, "</bold>", "**");
-  rv             = replaceAll(rv, "<BOLD>", "**");
-  rv             = replaceAll(rv, "</BOLD>", "**");
+  std::string rv = replaceAll(text, "<bold>", "<b>");
+  rv             = replaceAll(rv, "</bold>", "</b>");
+  rv             = replaceAll(rv, "<BOLD>", "<b>");
+  rv             = replaceAll(rv, "</BOLD>", "</b>");
+  rv             = replaceAll(rv, "&lt;bold&gt;", "<b>");
+  rv             = replaceAll(rv, "&lt;/bold&gt;", "</b>");
+  rv             = replaceAll(rv, "&lt;BOLD&gt;", "<b>");
+  rv             = replaceAll(rv, "&lt;/BOLD&gt;", "</b>");
   return rv;
 }
 

--- a/src/cfrmnodeconfig.cpp
+++ b/src/cfrmnodeconfig.cpp
@@ -92,34 +92,6 @@
 
 // ----------------------------------------------------------------------------
 
-static std::string
-replaceAll(std::string text, const std::string& from, const std::string& to)
-{
-  size_t pos = 0;
-  while (std::string::npos != (pos = text.find(from, pos))) {
-    text.replace(pos, from.length(), to);
-    pos += to.length();
-  }
-
-  return text;
-}
-
-static std::string
-normalizeBoldTags(const std::string& text)
-{
-  std::string rv = replaceAll(text, "<bold>", "<b>");
-  rv             = replaceAll(rv, "</bold>", "</b>");
-  rv             = replaceAll(rv, "<BOLD>", "<b>");
-  rv             = replaceAll(rv, "</BOLD>", "</b>");
-  rv             = replaceAll(rv, "&lt;bold&gt;", "<b>");
-  rv             = replaceAll(rv, "&lt;/bold&gt;", "</b>");
-  rv             = replaceAll(rv, "&lt;BOLD&gt;", "<b>");
-  rv             = replaceAll(rv, "&lt;/BOLD&gt;", "</b>");
-  return rv;
-}
-
-// ----------------------------------------------------------------------------
-
 CRegisterWidgetItem::CRegisterWidgetItem(const QString& text)
   : QTreeWidgetItem(TREE_LIST_REGISTER_TYPE)
 {
@@ -2071,8 +2043,7 @@ CFrmNodeConfig::fillDeviceHtmlInfo(void)
   html += "<br>";
 
   html += "</font><b>Module description:</b><font color=\"#009900\"> ";
-  std::string moduleDesc = normalizeBoldTags(m_mdf.getModuleDescription());
-  html += m_mdf.format(moduleDesc);
+  html += m_mdf.getModuleDescription();
   html += "<br>";
 
   html += "</font><b>Module URL</b><font color=\"#009900\"> : ";
@@ -4039,7 +4010,6 @@ CFrmNodeConfig::fillRegisterHtmlInfo(QTreeWidgetItem* item, int column)
   }
   else {
     str = preg->getDescription();
-    str  = normalizeBoldTags(str);
     html += m_mdf.format(str);
     // str = "# test\n";
     // str += "This _is_ som **test** text\n\nAnd some more text\n\n";
@@ -4528,7 +4498,6 @@ CFrmNodeConfig::fillRemoteVariableHtmlInfo(QTreeWidgetItem* item, int column)
   }
   else {
     std::string desc = prv->getDescription();
-    desc = normalizeBoldTags(desc);
     html += m_mdf.format(desc);
   }
   html += "<p>";
@@ -5286,11 +5255,9 @@ CFrmNodeConfig::fillDMHtmlInfo(QTreeWidgetItem* item, int column)
     html += "</font>";
     html += "<br> <b>Name:</b><font color=\"#000099\"> ";
     str = pAction->getName();
-    str  = normalizeBoldTags(str);
     html += m_mdf.format(str);
     html += "</font><br> <b>Description:</b><font color=\"#000099\"> ";
     str = pAction->getDescription();
-    str  = normalizeBoldTags(str);
     html += m_mdf.format(str);
     html += "</font>";
   }
@@ -5307,7 +5274,6 @@ CFrmNodeConfig::fillDMHtmlInfo(QTreeWidgetItem* item, int column)
   }
   else {
     std::string desc = QString::number(pitem->m_row).toStdString();
-    desc  = normalizeBoldTags(desc);
     html += m_mdf.format(desc);
   }
   html += "<p>";

--- a/src/cfrmnodeconfig.cpp
+++ b/src/cfrmnodeconfig.cpp
@@ -92,6 +92,30 @@
 
 // ----------------------------------------------------------------------------
 
+static std::string
+replaceAll(std::string text, const std::string& from, const std::string& to)
+{
+  size_t pos = 0;
+  while (std::string::npos != (pos = text.find(from, pos))) {
+    text.replace(pos, from.length(), to);
+    pos += to.length();
+  }
+
+  return text;
+}
+
+static std::string
+normalizeBoldTags(const std::string& text)
+{
+  std::string rv = replaceAll(text, "<bold>", "<b>");
+  rv             = replaceAll(rv, "</bold>", "</b>");
+  rv             = replaceAll(rv, "<BOLD>", "<b>");
+  rv             = replaceAll(rv, "</BOLD>", "</b>");
+  return rv;
+}
+
+// ----------------------------------------------------------------------------
+
 CRegisterWidgetItem::CRegisterWidgetItem(const QString& text)
   : QTreeWidgetItem(TREE_LIST_REGISTER_TYPE)
 {
@@ -882,6 +906,50 @@ CFrmNodeConfig::CFrmNodeConfig(QWidget* parent, json* pconn)
           &QAction::triggered,
           this,
           &CFrmNodeConfig::fillDeviceHtmlInfo);
+
+  QMenu* operationsMenu = new QMenu(tr("&Operations"), this);
+  auto addOpAction      = [this, operationsMenu](const QString& text, const char* slot) {
+    operationsMenu->addAction(text, this, slot);
+  };
+
+  operationsMenu->addSection(tr("Register operations"));
+  addOpAction(tr("Update"), SLOT(update()));
+  addOpAction(tr("Full update"), SLOT(updateFull()));
+  addOpAction(tr("Full update with local MDF"), SLOT(updateLocal()));
+  operationsMenu->addSeparator();
+  addOpAction(tr("Read value(s) for selected row(s)"), SLOT(readSelectedRegisterValues()));
+  addOpAction(tr("Write value(s) for selected row(s)"), SLOT(writeSelectedRegisterValues()));
+  addOpAction(tr("Write default value(s) for selected row(s)"), SLOT(defaultSelectedRegisterValues()));
+  addOpAction(tr("Set default values for ALL rows"), SLOT(defaultRegisterAll()));
+  operationsMenu->addSeparator();
+  addOpAction(tr("Save selected registers"), SLOT(saveSelectedRegisterValues()));
+  addOpAction(tr("Save ALL registers"), SLOT(saveAllRegisterValues()));
+  addOpAction(tr("Load registers"), SLOT(loadRegisterValues()));
+  addOpAction(tr("Goto register page..."), SLOT(gotoRegisterPage()));
+
+  operationsMenu->addSeparator();
+  operationsMenu->addSection(tr("Remote variable operations"));
+  addOpAction(tr("Go to register(s) for this remote variable"), SLOT(gotoRemoteVarRegisterPos()));
+  addOpAction(tr("Read value(s) for selected row(s)"), SLOT(readSelectedRegisterValues()));
+  addOpAction(tr("Write value(s) for selected row(s)"), SLOT(writeSelectedRegisterValues()));
+  addOpAction(tr("Write default value(s) for selected row(s)"), SLOT(defaultSelectedRegisterValues()));
+  addOpAction(tr("Set default values for ALL rows"), SLOT(defaultRegisterAll()));
+  addOpAction(tr("Save register value(s) for selected row(s) to disk"), SLOT(saveSelectedRegisterValues()));
+  addOpAction(tr("Save ALL register values to disk"), SLOT(saveAllRegisterValues()));
+  addOpAction(tr("Load register values from disk"), SLOT(loadRegisterValues()));
+
+  operationsMenu->addSeparator();
+  operationsMenu->addSection(tr("Decision Matrix operations"));
+  addOpAction(tr("Edit row"), SLOT(editDMRow()));
+  addOpAction(tr("Go to register position for row"), SLOT(gotoDMRegisterPos()));
+  addOpAction(tr("Enable/Disable selected row(s)"), SLOT(toggleDMRow()));
+  addOpAction(tr("Read selected DM row(s)"), SLOT(readSelectedDMRow()));
+  addOpAction(tr("Write selected DM row(s)"), SLOT(writeSelectedDMRow()));
+  addOpAction(tr("Save DM values for selected row(s) to disk"), SLOT(saveSelectedRegisterValues()));
+  addOpAction(tr("Save DM registers to disk"), SLOT(saveAllRegisterValues()));
+  addOpAction(tr("Load DM values from disk"), SLOT(loadRegisterValues()));
+
+  ui->menuBar->insertMenu(ui->menuHelp->menuAction(), operationsMenu);
 
   // MDF file item has been double clicked
 }
@@ -1999,7 +2067,8 @@ CFrmNodeConfig::fillDeviceHtmlInfo(void)
   html += "<br>";
 
   html += "</font><b>Module description:</b><font color=\"#009900\"> ";
-  html += m_mdf.getModuleDescription();
+  std::string moduleDesc = normalizeBoldTags(m_mdf.getModuleDescription());
+  html += m_mdf.format(moduleDesc);
   html += "<br>";
 
   html += "</font><b>Module URL</b><font color=\"#009900\"> : ";
@@ -3966,6 +4035,7 @@ CFrmNodeConfig::fillRegisterHtmlInfo(QTreeWidgetItem* item, int column)
   }
   else {
     str = preg->getDescription();
+    str  = normalizeBoldTags(str);
     html += m_mdf.format(str);
     // str = "# test\n";
     // str += "This _is_ som **test** text\n\nAnd some more text\n\n";
@@ -5211,9 +5281,11 @@ CFrmNodeConfig::fillDMHtmlInfo(QTreeWidgetItem* item, int column)
     html += "</font>";
     html += "<br> <b>Name:</b><font color=\"#000099\"> ";
     str = pAction->getName();
+    str  = normalizeBoldTags(str);
     html += m_mdf.format(str);
     html += "</font><br> <b>Description:</b><font color=\"#000099\"> ";
     str = pAction->getDescription();
+    str  = normalizeBoldTags(str);
     html += m_mdf.format(str);
     html += "</font>";
   }
@@ -5230,6 +5302,7 @@ CFrmNodeConfig::fillDMHtmlInfo(QTreeWidgetItem* item, int column)
   }
   else {
     std::string desc = QString::number(pitem->m_row).toStdString();
+    desc  = normalizeBoldTags(desc);
     html += m_mdf.format(desc);
   }
   html += "<p>";

--- a/src/cfrmnodeconfig.cpp
+++ b/src/cfrmnodeconfig.cpp
@@ -4214,7 +4214,7 @@ CFrmNodeConfig::findRemoteVariableForRegister(uint32_t offset, uint16_t page, ui
 
   const uint16_t regSpan = (0 == span) ? 1 : span;
   const uint64_t regStart = static_cast<uint64_t>(offset);
-  const uint64_t regEnd   = regStart + static_cast<uint64_t>(regSpan);
+  const uint64_t regEnd   = regStart + static_cast<uint64_t>(regSpan - 1);
 
   for (auto* pRemoteVariable : *pRemoteVariableList) {
     if (nullptr == pRemoteVariable) {
@@ -4228,7 +4228,7 @@ CFrmNodeConfig::findRemoteVariableForRegister(uint32_t offset, uint16_t page, ui
     const uint8_t rvSpan   = (0 == pRemoteVariable->getTypeByteCount()) ? 1 : pRemoteVariable->getTypeByteCount();
     const uint64_t rvStart = static_cast<uint64_t>(pRemoteVariable->getOffset());
     const uint64_t rvEnd   = rvStart + static_cast<uint64_t>(rvSpan);
-    if ((regStart < rvEnd) && (rvStart < regEnd)) {
+    if ((regStart <= rvEnd) && (rvStart <= regEnd)) {
       return pRemoteVariable;
     }
   }

--- a/src/cfrmnodeconfig.cpp
+++ b/src/cfrmnodeconfig.cpp
@@ -97,6 +97,7 @@ CRegisterWidgetItem::CRegisterWidgetItem(const QString& text)
 {
   m_regPage   = 0;
   m_regOffset = 0;
+  m_regSpan   = 1;
 }
 
 CRegisterWidgetItem::~CRegisterWidgetItem()
@@ -3775,6 +3776,7 @@ CFrmNodeConfig::renderRegisters(void)
       // Save reister info so we can find info later
       itemReg->m_regPage   = page;
       itemReg->m_regOffset = pregmdf->getOffset();
+      itemReg->m_regSpan   = pregmdf->getSpan();
 
       // Save a pointer to register information
       // itemReg->m_pmdfreg = pregmdf;
@@ -3827,7 +3829,7 @@ CFrmNodeConfig::renderRegisters(void)
       itemReg->setTextAlignment(REG_COL_NAME, Qt::AlignLeft);
       itemTopReg1->addChild(itemReg);
 
-      CMDF_RemoteVariable* pRemoteVariable = findRemoteVariableForRegister(itemReg->m_regOffset, itemReg->m_regPage);
+      CMDF_RemoteVariable* pRemoteVariable = findRemoteVariableForRegister(itemReg->m_regOffset, itemReg->m_regPage, itemReg->m_regSpan);
       QPushButton* pRemoteVarButton        = new QPushButton(ui->treeWidgetRegisters);
       pRemoteVarButton->setAutoDefault(false);
       pRemoteVarButton->setDefault(false);
@@ -3837,7 +3839,7 @@ CFrmNodeConfig::renderRegisters(void)
         connect(pRemoteVarButton,
                 &QPushButton::clicked,
                 this,
-                [this, page = itemReg->m_regPage, offset = itemReg->m_regOffset]() { openRemoteVariableForRegister(offset, page); });
+                [this, page = itemReg->m_regPage, offset = itemReg->m_regOffset, span = itemReg->m_regSpan]() { openRemoteVariableForRegister(offset, page, span); });
       }
       else {
         pRemoteVarButton->setText(tr("Add remote variable"));
@@ -4203,12 +4205,16 @@ CFrmNodeConfig::updateChangeRemoteVariable(uint32_t offset, uint16_t page, bool 
 //
 
 CMDF_RemoteVariable*
-CFrmNodeConfig::findRemoteVariableForRegister(uint32_t offset, uint16_t page)
+CFrmNodeConfig::findRemoteVariableForRegister(uint32_t offset, uint16_t page, uint16_t span)
 {
   std::deque<CMDF_RemoteVariable*>* pRemoteVariableList = m_mdf.getRemoteVariableList();
   if (nullptr == pRemoteVariableList) {
     return nullptr;
   }
+
+  const uint16_t regSpan = (0 == span) ? 1 : span;
+  const uint64_t regStart = static_cast<uint64_t>(offset);
+  const uint64_t regEnd   = regStart + static_cast<uint64_t>(regSpan);
 
   for (auto* pRemoteVariable : *pRemoteVariableList) {
     if (nullptr == pRemoteVariable) {
@@ -4219,8 +4225,10 @@ CFrmNodeConfig::findRemoteVariableForRegister(uint32_t offset, uint16_t page)
       continue;
     }
 
-    if ((offset >= pRemoteVariable->getOffset()) &&
-        (offset < (pRemoteVariable->getOffset() + pRemoteVariable->getTypeByteCount()))) {
+    const uint8_t rvSpan   = (0 == pRemoteVariable->getTypeByteCount()) ? 1 : pRemoteVariable->getTypeByteCount();
+    const uint64_t rvStart = static_cast<uint64_t>(pRemoteVariable->getOffset());
+    const uint64_t rvEnd   = rvStart + static_cast<uint64_t>(rvSpan);
+    if ((regStart < rvEnd) && (rvStart < regEnd)) {
       return pRemoteVariable;
     }
   }
@@ -4233,9 +4241,9 @@ CFrmNodeConfig::findRemoteVariableForRegister(uint32_t offset, uint16_t page)
 //
 
 void
-CFrmNodeConfig::openRemoteVariableForRegister(uint32_t offset, uint16_t page)
+CFrmNodeConfig::openRemoteVariableForRegister(uint32_t offset, uint16_t page, uint16_t span)
 {
-  CMDF_RemoteVariable* pRemoteVariable = findRemoteVariableForRegister(offset, page);
+  CMDF_RemoteVariable* pRemoteVariable = findRemoteVariableForRegister(offset, page, span);
   if (nullptr == pRemoteVariable) {
     addRemoteVariableForRegister(offset, page);
     return;

--- a/src/cfrmnodeconfig.h
+++ b/src/cfrmnodeconfig.h
@@ -144,6 +144,11 @@ public:
     Register offset
   */
   uint32_t m_regOffset;
+
+  /*!
+    Register span in bytes.
+  */
+  uint16_t m_regSpan;
 };
 
 // ----------------------------------------------------------------------------
@@ -759,12 +764,12 @@ public slots:
   /*!
     Get remote variable containing register offset on page.
   */
-  CMDF_RemoteVariable* findRemoteVariableForRegister(uint32_t offset, uint16_t page);
+  CMDF_RemoteVariable* findRemoteVariableForRegister(uint32_t offset, uint16_t page, uint16_t span = 1);
 
   /*!
     Open remote variable dialog for register.
   */
-  void openRemoteVariableForRegister(uint32_t offset, uint16_t page);
+  void openRemoteVariableForRegister(uint32_t offset, uint16_t page, uint16_t span = 1);
 
   /*!
     Add a new remote variable with page/offset prefilled from register.

--- a/src/cfrmnodeconfig.h
+++ b/src/cfrmnodeconfig.h
@@ -92,7 +92,9 @@ enum registerColumns {
   REG_COL_POS = 0,
   REG_COL_ACCESS,
   REG_COL_VALUE,
-  REG_COL_NAME
+  REG_COL_NAME,
+  REG_COL_REMOTEVAR,
+  REG_COL_COUNT
 };
 
 enum remotevarColumns {
@@ -753,6 +755,21 @@ public slots:
     @param bFromRegUpdate True if called from register update
   */
   void updateChangeRemoteVariable(uint32_t offset, uint16_t page, bool bFromRegUpdate = false);
+
+  /*!
+    Get remote variable containing register offset on page.
+  */
+  CMDF_RemoteVariable* findRemoteVariableForRegister(uint32_t offset, uint16_t page);
+
+  /*!
+    Open remote variable dialog for register.
+  */
+  void openRemoteVariableForRegister(uint32_t offset, uint16_t page);
+
+  /*!
+    Add a new remote variable with page/offset prefilled from register.
+  */
+  void addRemoteVariableForRegister(uint32_t offset, uint16_t page);
 
   /*!
     Update DM listing


### PR DESCRIPTION
## Summary\n- harden MDF parsing/editing for unicode JSON/XML and improve save/open UX\n- enforce ISO date formatting in MDF dialogs and editor views\n- fix double-click editing behavior and alarm bit parsing issues\n- add backup-before-save and recent file handling improvements\n- improve register/remote-variable linking behavior and module buffer-size rules\n\n## Notes\nThis branch includes the follow-up fixes requested during validation.