### PR TITLE
Add SocketCAN frame session window with CAN FD support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,6 +238,8 @@ qt_add_executable(${PROJECT_NAME}
 
   src/cfrmsession.h
   src/cfrmsession.cpp
+  src/cfrmrawcansession.h
+  src/cfrmrawcansession.cpp
   src/cfrmvscplinktest.h
   src/cfrmvscplinktest.cpp
 
@@ -635,6 +637,8 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
   Qt6::Qml
   Qt6::Charts
   Qt6::Help
+  Qt6::SerialBus
+  Qt6::SerialPort
   PThreads4W::PThreads4W
   OpenSSL::SSL
   OpenSSL::Crypto
@@ -652,6 +656,8 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
   Qt6::Qml
   Qt6::Charts
   Qt6::Help
+  Qt6::SerialBus
+  Qt6::SerialPort
   m
   dl
   Threads::Threads

--- a/docs/connection_socketcan.md
+++ b/docs/connection_socketcan.md
@@ -44,6 +44,10 @@ Select the connection you want to clone in the treeview and right click. Select 
 
 Select the connection you want to connect to in the treeview and right click. Select the service your want (session/configure/scan/firmware load) in the context menu. The connection will be established.
 
+## Open a raw SocketCAN frame session
+
+For SocketCAN connections there is also a dedicated frame session window available from the connection context menu as **SocketCAN frame session**. This window can send and receive both standard CAN and CAN FD frames.
+
 ## Testing
 
 If you have can utils installed you can use the `cansend` and `candump` utilities to test your the socketcan support of VSCP Works. You can install can-utils with the following commands.
@@ -114,5 +118,4 @@ This will send a [CLASS1.INFORMATION, VSCP_TYPE_INFORMATION_ON](https://grodansp
 ![](./images/socketcan_test_vcan0_response.png)
 
 The socketcan representation may be awkward at first but this is just the way VSCP packs VSCP events into CAN frames. You can read more about this [here](https://grodansparadis.github.io/vscp-doc-spec/#/./vscp_over_can_can4vscp).
-
 

--- a/src/cfrmrawcansession.cpp
+++ b/src/cfrmrawcansession.cpp
@@ -1,0 +1,512 @@
+// cfrmrawcansession.cpp
+//
+// This file is part of the VSCP (https://www.vscp.org)
+//
+// The MIT License (MIT)
+//
+// Copyright (C) 2000-2026 Ake Hedman, Grodans Paradis AB
+// <info@grodansparadis.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+#ifdef WIN32
+#include <pch.h>
+#endif
+
+#ifndef WIN32
+
+#include "cfrmrawcansession.h"
+
+#include <QDateTime>
+#include <QDesktopServices>
+#include <QGridLayout>
+#include <QGroupBox>
+#include <QHBoxLayout>
+#include <QHeaderView>
+#include <QMessageBox>
+#include <QUrl>
+#include <QVBoxLayout>
+#include <QtSerialBus/QCanBus>
+
+// ----------------------------------------------------------------------------
+
+CFrmRawCanSession::CFrmRawCanSession(QWidget* parent, json* pconn)
+  : QDialog(parent)
+  , m_canDevice(nullptr)
+  , m_statusLabel(nullptr)
+  , m_editFrameId(nullptr)
+  , m_editPayload(nullptr)
+  , m_chkExtended(nullptr)
+  , m_chkFd(nullptr)
+  , m_chkBitrateSwitch(nullptr)
+  , m_chkErrorStateIndicator(nullptr)
+  , m_chkRemoteRequest(nullptr)
+  , m_btnConnect(nullptr)
+  , m_btnSend(nullptr)
+  , m_btnClear(nullptr)
+  , m_tableFrames(nullptr)
+{
+  if (nullptr != pconn) {
+    m_connObject = *pconn;
+  }
+
+  if (m_connObject.contains("device") && m_connObject["device"].is_string()) {
+    m_interfaceName = m_connObject["device"].get<std::string>().c_str();
+  }
+
+  setupUi();
+  setConnectedState(false);
+}
+
+CFrmRawCanSession::~CFrmRawCanSession()
+{
+  if (nullptr != m_canDevice) {
+    m_canDevice->disconnectDevice();
+    delete m_canDevice;
+    m_canDevice = nullptr;
+  }
+}
+
+// ----------------------------------------------------------------------------
+
+void
+CFrmRawCanSession::setupUi()
+{
+  setWindowTitle(tr("SocketCAN frame session - %1")
+                   .arg(m_interfaceName.isEmpty() ? tr("Unknown device") : m_interfaceName));
+  resize(1150, 720);
+
+  QVBoxLayout* mainLayout = new QVBoxLayout(this);
+
+  QHBoxLayout* topLayout = new QHBoxLayout;
+  m_btnConnect           = new QPushButton(tr("Connect"), this);
+  m_btnClear             = new QPushButton(tr("Clear"), this);
+  QPushButton* btnHelp   = new QPushButton(tr("Help"), this);
+  m_statusLabel          = new QLabel(this);
+  m_statusLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
+
+  topLayout->addWidget(m_btnConnect);
+  topLayout->addWidget(m_btnClear);
+  topLayout->addWidget(btnHelp);
+  topLayout->addStretch(1);
+  topLayout->addWidget(m_statusLabel, 1);
+  mainLayout->addLayout(topLayout);
+
+  m_tableFrames = new QTableWidget(this);
+  m_tableFrames->setColumnCount(7);
+  m_tableFrames->setAlternatingRowColors(true);
+  m_tableFrames->setSelectionBehavior(QAbstractItemView::SelectRows);
+  m_tableFrames->setEditTriggers(QAbstractItemView::NoEditTriggers);
+  m_tableFrames->setHorizontalHeaderLabels(
+    QStringList() << tr("Time")
+                  << tr("Dir")
+                  << tr("ID")
+                  << tr("Format")
+                  << tr("Type")
+                  << tr("DLC")
+                  << tr("Data"));
+  m_tableFrames->horizontalHeader()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
+  m_tableFrames->horizontalHeader()->setSectionResizeMode(1, QHeaderView::ResizeToContents);
+  m_tableFrames->horizontalHeader()->setSectionResizeMode(2, QHeaderView::ResizeToContents);
+  m_tableFrames->horizontalHeader()->setSectionResizeMode(3, QHeaderView::ResizeToContents);
+  m_tableFrames->horizontalHeader()->setSectionResizeMode(4, QHeaderView::ResizeToContents);
+  m_tableFrames->horizontalHeader()->setSectionResizeMode(5, QHeaderView::ResizeToContents);
+  m_tableFrames->horizontalHeader()->setStretchLastSection(true);
+  mainLayout->addWidget(m_tableFrames, 1);
+
+  QGroupBox* sendBox     = new QGroupBox(tr("Send frame"), this);
+  QGridLayout* sendLayout = new QGridLayout(sendBox);
+
+  m_editFrameId = new QLineEdit(sendBox);
+  m_editFrameId->setPlaceholderText(tr("Example: 0x123 or 291"));
+  m_editPayload = new QLineEdit(sendBox);
+  m_editPayload->setPlaceholderText(tr("Hex bytes: 11 22 33 or 112233"));
+
+  m_chkExtended            = new QCheckBox(tr("Extended ID (29-bit)"), sendBox);
+  m_chkFd                  = new QCheckBox(tr("CAN FD"), sendBox);
+  m_chkBitrateSwitch       = new QCheckBox(tr("Bitrate switch (BRS)"), sendBox);
+  m_chkErrorStateIndicator = new QCheckBox(tr("Error state indicator (ESI)"), sendBox);
+  m_chkRemoteRequest       = new QCheckBox(tr("Remote request"), sendBox);
+
+  m_btnSend = new QPushButton(tr("Send"), sendBox);
+
+  sendLayout->addWidget(new QLabel(tr("Frame ID"), sendBox), 0, 0);
+  sendLayout->addWidget(m_editFrameId, 0, 1, 1, 3);
+  sendLayout->addWidget(new QLabel(tr("Payload"), sendBox), 1, 0);
+  sendLayout->addWidget(m_editPayload, 1, 1, 1, 3);
+  sendLayout->addWidget(m_chkExtended, 2, 0);
+  sendLayout->addWidget(m_chkFd, 2, 1);
+  sendLayout->addWidget(m_chkBitrateSwitch, 2, 2);
+  sendLayout->addWidget(m_chkErrorStateIndicator, 2, 3);
+  sendLayout->addWidget(m_chkRemoteRequest, 3, 0, 1, 2);
+  sendLayout->addWidget(m_btnSend, 3, 3);
+
+  mainLayout->addWidget(sendBox);
+
+  connect(m_btnConnect, &QPushButton::clicked, this, &CFrmRawCanSession::connectOrDisconnect);
+  connect(m_btnSend, &QPushButton::clicked, this, &CFrmRawCanSession::sendFrame);
+  connect(m_btnClear, &QPushButton::clicked, this, &CFrmRawCanSession::clearLog);
+  connect(btnHelp, &QPushButton::clicked, this, &CFrmRawCanSession::showHelp);
+}
+
+// ----------------------------------------------------------------------------
+
+void
+CFrmRawCanSession::connectOrDisconnect()
+{
+  if (nullptr != m_canDevice) {
+    m_canDevice->disconnectDevice();
+    delete m_canDevice;
+    m_canDevice = nullptr;
+    setConnectedState(false);
+    return;
+  }
+
+  if (m_interfaceName.isEmpty()) {
+    QMessageBox::warning(this,
+                         tr("VSCP Works"),
+                         tr("No SocketCAN interface is configured for this connection."),
+                         QMessageBox::Ok);
+    return;
+  }
+
+  QString errorString;
+  m_canDevice = QCanBus::instance()->createDevice(QStringLiteral("socketcan"),
+                                                  m_interfaceName,
+                                                  &errorString);
+  if (nullptr == m_canDevice) {
+    QMessageBox::warning(this,
+                         tr("VSCP Works"),
+                         tr("Failed to create SocketCAN device: %1").arg(errorString),
+                         QMessageBox::Ok);
+    setConnectedState(false);
+    return;
+  }
+
+  m_canDevice->setConfigurationParameter(QCanBusDevice::CanFdKey, true);
+  m_canDevice->setConfigurationParameter(QCanBusDevice::ReceiveOwnKey, true);
+
+  connect(m_canDevice, &QCanBusDevice::framesReceived, this, &CFrmRawCanSession::processReceivedFrames);
+  connect(m_canDevice, &QCanBusDevice::errorOccurred, this, &CFrmRawCanSession::processError);
+
+  if (!m_canDevice->connectDevice()) {
+    QMessageBox::warning(this,
+                         tr("VSCP Works"),
+                         tr("Failed to connect to interface %1: %2")
+                           .arg(m_interfaceName)
+                           .arg(m_canDevice->errorString()),
+                         QMessageBox::Ok);
+    delete m_canDevice;
+    m_canDevice = nullptr;
+    setConnectedState(false);
+    return;
+  }
+
+  setConnectedState(true);
+}
+
+// ----------------------------------------------------------------------------
+
+void
+CFrmRawCanSession::sendFrame()
+{
+  if (nullptr == m_canDevice) {
+    QMessageBox::warning(this,
+                         tr("VSCP Works"),
+                         tr("Not connected to a SocketCAN interface."),
+                         QMessageBox::Ok);
+    return;
+  }
+
+  uint32_t frameId = 0;
+  if (!parseFrameId(frameId)) {
+    return;
+  }
+
+  QByteArray payload;
+  if (!parsePayload(payload)) {
+    return;
+  }
+
+  if (!m_chkExtended->isChecked() && (frameId > 0x7FFU)) {
+    QMessageBox::warning(this,
+                         tr("VSCP Works"),
+                         tr("Standard CAN identifiers are limited to 0x7FF."),
+                         QMessageBox::Ok);
+    return;
+  }
+
+  if (m_chkExtended->isChecked() && (frameId > 0x1FFFFFFFU)) {
+    QMessageBox::warning(this,
+                         tr("VSCP Works"),
+                         tr("Extended CAN identifiers are limited to 0x1FFFFFFF."),
+                         QMessageBox::Ok);
+    return;
+  }
+
+  if (m_chkFd->isChecked()) {
+    const int size = payload.size();
+    const bool validFdSize = (size <= 8) || (size == 12) || (size == 16) || (size == 20) ||
+                             (size == 24) || (size == 32) || (size == 48) || (size == 64);
+    if (!validFdSize) {
+      QMessageBox::warning(this,
+                           tr("VSCP Works"),
+                           tr("CAN FD payload length must be 0-8, 12, 16, 20, 24, 32, 48 or 64 bytes."),
+                           QMessageBox::Ok);
+      return;
+    }
+  }
+  else if (payload.size() > 8) {
+    QMessageBox::warning(this,
+                         tr("VSCP Works"),
+                         tr("Standard CAN payload length must be 0-8 bytes."),
+                         QMessageBox::Ok);
+    return;
+  }
+
+  if (m_chkFd->isChecked() && m_chkRemoteRequest->isChecked()) {
+    QMessageBox::warning(this,
+                         tr("VSCP Works"),
+                         tr("Remote request frames are not supported for CAN FD."),
+                         QMessageBox::Ok);
+    return;
+  }
+
+  QCanBusFrame frame(frameId, payload);
+  frame.setExtendedFrameFormat(m_chkExtended->isChecked());
+  frame.setFlexibleDataRateFormat(m_chkFd->isChecked());
+  frame.setBitrateSwitch(m_chkBitrateSwitch->isChecked());
+  frame.setErrorStateIndicator(m_chkErrorStateIndicator->isChecked());
+  frame.setFrameType(m_chkRemoteRequest->isChecked()
+                       ? QCanBusFrame::RemoteRequestFrame
+                       : QCanBusFrame::DataFrame);
+
+  if (!m_canDevice->writeFrame(frame)) {
+    QMessageBox::warning(this,
+                         tr("VSCP Works"),
+                         tr("Failed to send frame: %1").arg(m_canDevice->errorString()),
+                         QMessageBox::Ok);
+    return;
+  }
+
+  appendFrame(frame, tr("TX"));
+}
+
+// ----------------------------------------------------------------------------
+
+void
+CFrmRawCanSession::processReceivedFrames()
+{
+  while ((nullptr != m_canDevice) && m_canDevice->framesAvailable()) {
+    appendFrame(m_canDevice->readFrame(), tr("RX"));
+  }
+}
+
+// ----------------------------------------------------------------------------
+
+void
+CFrmRawCanSession::processError(QCanBusDevice::CanBusError error)
+{
+  if ((nullptr == m_canDevice) || (QCanBusDevice::NoError == error)) {
+    return;
+  }
+
+  m_statusLabel->setText(tr("Error: %1").arg(m_canDevice->errorString()));
+}
+
+// ----------------------------------------------------------------------------
+
+void
+CFrmRawCanSession::clearLog()
+{
+  m_tableFrames->setRowCount(0);
+}
+
+// ----------------------------------------------------------------------------
+
+void
+CFrmRawCanSession::showHelp()
+{
+  const QString link = "https://grodansparadis.github.io/vscp-works-qt/#/rawcan_window";
+  QDesktopServices::openUrl(QUrl(link));
+}
+
+// ----------------------------------------------------------------------------
+
+void
+CFrmRawCanSession::appendFrame(const QCanBusFrame& frame, const QString& direction)
+{
+  const int row = m_tableFrames->rowCount();
+  m_tableFrames->insertRow(row);
+
+  const QString ts = QDateTime::currentDateTime().toString(Qt::ISODateWithMs);
+  const QString frameType = (QCanBusFrame::DataFrame == frame.frameType())
+                              ? tr("Data")
+                              : (QCanBusFrame::RemoteRequestFrame == frame.frameType())
+                                  ? tr("Remote")
+                                  : tr("Other");
+  const QString id = frame.hasExtendedFrameFormat()
+                       ? QString("0x%1").arg(frame.frameId(), 8, 16, QChar('0')).toUpper()
+                       : QString("0x%1").arg(frame.frameId(), 3, 16, QChar('0')).toUpper();
+
+  m_tableFrames->setItem(row, 0, new QTableWidgetItem(ts));
+  m_tableFrames->setItem(row, 1, new QTableWidgetItem(direction));
+  m_tableFrames->setItem(row, 2, new QTableWidgetItem(id));
+  m_tableFrames->setItem(row, 3, new QTableWidgetItem(frame.hasExtendedFrameFormat() ? tr("EXT") : tr("STD")));
+  m_tableFrames->setItem(row, 4, new QTableWidgetItem(frameType + " " + frameFlagsToString(frame)));
+  m_tableFrames->setItem(row, 5, new QTableWidgetItem(QString::number(frame.payload().size())));
+  m_tableFrames->setItem(row, 6, new QTableWidgetItem(formatPayload(frame.payload())));
+  m_tableFrames->scrollToBottom();
+}
+
+// ----------------------------------------------------------------------------
+
+void
+CFrmRawCanSession::setConnectedState(bool connected)
+{
+  m_btnConnect->setText(connected ? tr("Disconnect") : tr("Connect"));
+  m_btnSend->setEnabled(connected);
+  m_statusLabel->setText(connected
+                           ? tr("Connected to %1").arg(m_interfaceName)
+                           : tr("Disconnected"));
+}
+
+// ----------------------------------------------------------------------------
+
+bool
+CFrmRawCanSession::parseFrameId(uint32_t& id)
+{
+  QString str = m_editFrameId->text().trimmed();
+  if (str.isEmpty()) {
+    QMessageBox::warning(this, tr("VSCP Works"), tr("Frame ID is required."), QMessageBox::Ok);
+    return false;
+  }
+
+  int base = 10;
+  if (str.startsWith("0x", Qt::CaseInsensitive)) {
+    str  = str.mid(2);
+    base = 16;
+  }
+  else if (str.startsWith("0b", Qt::CaseInsensitive)) {
+    str  = str.mid(2);
+    base = 2;
+  }
+  else if (str.startsWith("0o", Qt::CaseInsensitive)) {
+    str  = str.mid(2);
+    base = 8;
+  }
+
+  bool ok            = false;
+  const uint64_t val = str.toULongLong(&ok, base);
+  if (!ok) {
+    QMessageBox::warning(this,
+                         tr("VSCP Works"),
+                         tr("Frame ID is not a valid number."),
+                         QMessageBox::Ok);
+    return false;
+  }
+
+  id = static_cast<uint32_t>(val);
+  return true;
+}
+
+// ----------------------------------------------------------------------------
+
+bool
+CFrmRawCanSession::parsePayload(QByteArray& payload)
+{
+  payload.clear();
+  QString str = m_editPayload->text().trimmed();
+  if (str.isEmpty()) {
+    return true;
+  }
+
+  str.replace(",", " ");
+  str.replace("-", " ");
+  const QStringList parts = str.split(" ", Qt::SkipEmptyParts);
+
+  if (parts.size() > 1) {
+    for (const QString& part : parts) {
+      bool ok      = false;
+      const int bt = part.toInt(&ok, 16);
+      if (!ok || bt < 0 || bt > 255) {
+        QMessageBox::warning(this,
+                             tr("VSCP Works"),
+                             tr("Payload contains invalid hex byte: %1").arg(part),
+                             QMessageBox::Ok);
+        return false;
+      }
+      payload.append(static_cast<char>(bt));
+    }
+    return true;
+  }
+
+  str.remove("0x");
+  str.remove("0X");
+  str.remove(" ");
+
+  if (str.length() % 2) {
+    QMessageBox::warning(this,
+                         tr("VSCP Works"),
+                         tr("Payload must contain an even number of hex digits."),
+                         QMessageBox::Ok);
+    return false;
+  }
+
+  const QByteArray data = QByteArray::fromHex(str.toLatin1());
+  if ((str.length() > 0) && data.isEmpty()) {
+    QMessageBox::warning(this,
+                         tr("VSCP Works"),
+                         tr("Failed to parse payload as hexadecimal data."),
+                         QMessageBox::Ok);
+    return false;
+  }
+
+  payload = data;
+  return true;
+}
+
+// ----------------------------------------------------------------------------
+
+QString
+CFrmRawCanSession::formatPayload(const QByteArray& payload) const
+{
+  return QString(payload.toHex(' ')).toUpper();
+}
+
+// ----------------------------------------------------------------------------
+
+QString
+CFrmRawCanSession::frameFlagsToString(const QCanBusFrame& frame) const
+{
+  QStringList flags;
+  if (frame.hasFlexibleDataRateFormat()) {
+    flags << tr("FD");
+  }
+  if (frame.hasBitrateSwitch()) {
+    flags << tr("BRS");
+  }
+  if (frame.hasErrorStateIndicator()) {
+    flags << tr("ESI");
+  }
+  return flags.join("|");
+}
+
+#endif // !WIN32

--- a/src/cfrmrawcansession.h
+++ b/src/cfrmrawcansession.h
@@ -1,0 +1,93 @@
+// cfrmrawcansession.h
+//
+// This file is part of the VSCP (https://www.vscp.org)
+//
+// The MIT License (MIT)
+//
+// Copyright (C) 2000-2026 Ake Hedman, Grodans Paradis AB
+// <info@grodansparadis.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+#ifndef CFRMRAWCANSESSION_H
+#define CFRMRAWCANSESSION_H
+
+#ifndef WIN32
+
+#include <QtSerialBus/QCanBusDevice>
+#include <QtSerialBus/QCanBusFrame>
+
+#include <QCheckBox>
+#include <QDialog>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QTableWidget>
+
+#include <nlohmann/json.hpp>
+using json = nlohmann::json;
+
+class CFrmRawCanSession : public QDialog
+{
+  Q_OBJECT
+
+public:
+  explicit CFrmRawCanSession(QWidget* parent, json* pconn);
+  ~CFrmRawCanSession();
+
+private slots:
+  void connectOrDisconnect();
+  void sendFrame();
+  void processReceivedFrames();
+  void processError(QCanBusDevice::CanBusError error);
+  void clearLog();
+  void showHelp();
+
+private:
+  void setupUi();
+  void appendFrame(const QCanBusFrame& frame, const QString& direction);
+  void setConnectedState(bool connected);
+  bool parseFrameId(uint32_t& id);
+  bool parsePayload(QByteArray& payload);
+  QString formatPayload(const QByteArray& payload) const;
+  QString frameFlagsToString(const QCanBusFrame& frame) const;
+
+  json m_connObject;
+  QString m_interfaceName;
+
+  QCanBusDevice* m_canDevice;
+
+  QLabel* m_statusLabel;
+  QLineEdit* m_editFrameId;
+  QLineEdit* m_editPayload;
+  QCheckBox* m_chkExtended;
+  QCheckBox* m_chkFd;
+  QCheckBox* m_chkBitrateSwitch;
+  QCheckBox* m_chkErrorStateIndicator;
+  QCheckBox* m_chkRemoteRequest;
+  QPushButton* m_btnConnect;
+  QPushButton* m_btnSend;
+  QPushButton* m_btnClear;
+  QTableWidget* m_tableFrames;
+};
+
+#endif // !WIN32
+
+#endif // CFRMRAWCANSESSION_H

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -68,6 +68,7 @@
 #include "cfrmmdf.h"
 #include "cfrmnodeconfig.h"
 #include "cfrmnodescan.h"
+#include "cfrmrawcansession.h"
 #include "cfrmsession.h"
 #include "cfrmvscplinktest.h"
 #include "filedownloader.h"
@@ -1163,6 +1164,14 @@ MainWindow::showConnectionContextMenu(const QPoint& pos)
                     QString(tr("Session")),
                     this,
                     SLOT(newSession()));
+#ifndef WIN32
+    if (static_cast<int>(CVscpClient::connType::SOCKETCAN) == item->parent()->type()) {
+      menu->addAction(newSessionIcon,
+                      QString(tr("SocketCAN frame session")),
+                      this,
+                      SLOT(newRawCanSession()));
+    }
+#endif
 
     const QIcon devConfigIcon = QIcon(":/page_process.png");
     menu->addAction(devConfigIcon,
@@ -1485,6 +1494,16 @@ MainWindow::createActions()
   connect(newSessionAct, &QAction::triggered, this, &MainWindow::newSession);
   fileMenu->addAction(newSessionAct);
   fileToolBar->addAction(newSessionAct);
+
+#ifndef WIN32
+  const QIcon newRawCanSessionIcon = QIcon(":/page.png");
+  QAction* newRawCanSessionAct =
+    new QAction(newRawCanSessionIcon, tr("SocketCAN &frame session..."), this);
+  newRawCanSessionAct->setStatusTip(tr("Open a SocketCAN raw frame session window"));
+  connect(newRawCanSessionAct, &QAction::triggered, this, &MainWindow::newRawCanSession);
+  fileMenu->addAction(newRawCanSessionAct);
+  fileToolBar->addAction(newRawCanSessionAct);
+#endif
 
   // Node configuration
   const QIcon newDevConfigIcon = QIcon(":/page_process.png");
@@ -1902,6 +1921,52 @@ MainWindow::newSession()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// newRawCanSession
+//
+
+void
+MainWindow::newRawCanSession()
+{
+#ifndef WIN32
+  QList<QTreeWidgetItem*> itemList = m_connTreeTable->selectedItems();
+
+  if (!itemList.size()) {
+    QMessageBox::warning(this,
+                         tr("VSCP Works+"),
+                         tr("No connection selected.\n"
+                            "Please select a SocketCAN connection first."));
+    return;
+  }
+
+  foreach (QTreeWidgetItem* item, itemList) {
+
+    // Not interested in top level items
+    if (NULL == item->parent()) {
+      continue;
+    }
+
+    treeWidgetItemConn* itemConn = (treeWidgetItemConn*)item;
+    json* pconn                  = itemConn->getJson();
+    if (!(pconn->contains("type") && (*pconn)["type"].is_number())) {
+      continue;
+    }
+
+    if ((*pconn)["type"].get<int>() != static_cast<int>(CVscpClient::connType::SOCKETCAN)) {
+      continue;
+    }
+
+    CFrmRawCanSession* w = new CFrmRawCanSession(this, pconn);
+    w->setAttribute(Qt::WA_DeleteOnClose, true); // Make window close on exit
+    w->setWindowState((windowState() & ~Qt::WindowMinimized) | Qt::WindowActive);
+    w->setWindowFlags(Qt::Window);
+    w->show();
+    w->raise();
+    w->activateWindow();
+  }
+#endif
+}
+
+/////////////////////////////////////////////////////////////////////////////////
 // newVscpLinkProtocolTest
 //
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -131,6 +131,7 @@ private slots:
     void commitData(QSessionManager &);
 #endif
     void newSession();
+    void newRawCanSession();
     void newNodeConfiguration();
     void newNodeScan();
     void newNodeBootload();

--- a/vscpworks.pro
+++ b/vscpworks.pro
@@ -43,6 +43,7 @@ SOURCES +=  src/main.cpp \
     src/cdlgcanfilter.cpp \
     src/cdlgtls.cpp \
     src/cfrmsession.cpp \
+    src/cfrmrawcansession.cpp \
     src/cfrmvscplinktest.cpp \
     src/vscpworks.cpp \
     src/canalconfigwizard.cpp \
@@ -101,6 +102,7 @@ HEADERS  += src/vscpworks.h \
     src/cdlgcanfilter.h \
     src/cdlgtls.h \
     src/cfrmsession.h \
+    src/cfrmrawcansession.h \
     src/cfrmvscplinktest.h \
     src/canalconfigwizard.h \
     vscp/src/vscp/common/version.h \


### PR DESCRIPTION
## Summary
- add a dedicated `CFrmRawCanSession` window for SocketCAN frame-level work
- support connect/disconnect, RX log, and TX of both standard CAN and CAN FD frames
- include frame options for extended ID, BRS, ESI, and remote request where applicable
- expose the window from SocketCAN connection context menu and File/toolbar actions
- wire new files into both CMake and qmake build flows
- update SocketCAN docs with the new frame session entry point

## Notes
- build was verified with Qt from `~/Qt` (`6.11.1/gcc_64`)
- this uses Qt SerialBus/SerialPort linkage in CMake for the new SocketCAN UI window