### PR TITLE
Add MQTT Explorer session window

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,6 +238,8 @@ qt_add_executable(${PROJECT_NAME}
 
   src/cfrmsession.h
   src/cfrmsession.cpp
+  src/cfrmmqttexplorer.h
+  src/cfrmmqttexplorer.cpp
   src/cfrmvscplinktest.h
   src/cfrmvscplinktest.cpp
 

--- a/src/cdlgconnsettingsrawmqtt.cpp
+++ b/src/cdlgconnsettingsrawmqtt.cpp
@@ -78,9 +78,6 @@ CDlgConnSettingsRawMqtt::CDlgConnSettingsRawMqtt(QWidget* parent)
   setUser("admin");
   setPassword("secret");
 
-  // Clear filter
-  memset(&m_filter, 0, sizeof(vscp_event_filter_t));
-
   connect(ui->btnTLS,
           &QPushButton::clicked,
           this,
@@ -116,11 +113,9 @@ CDlgConnSettingsRawMqtt::CDlgConnSettingsRawMqtt(QWidget* parent)
           this,
           &CDlgConnSettingsRawMqtt::onPublishContextMenu);
 
-          QShortcut * shortcut = new QShortcut(QKeySequence(Qt::Key_F1),this,SLOT(showHelp()));
-shortcut->setAutoRepeat(false);
-
-QPushButton* helpButton = ui->buttonBox->button(QDialogButtonBox::Help);
-connect(ui->helpButton, SIGNAL(clicked()), this, SLOT(showHelp()));
+  QShortcut* shortcut =
+    new QShortcut(QKeySequence(Qt::Key_F1), this, SLOT(showHelp()));
+  shortcut->setAutoRepeat(false);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -297,9 +292,7 @@ CDlgConnSettingsRawMqtt::getResponseTimeout(void)
 void
 CDlgConnSettingsRawMqtt::setResponseTimeout(uint32_t timeout)
 {
-  vscpworks* pworks = (vscpworks*)QCoreApplication::instance();
-  QString str       = pworks->decimalToStringInBase(timeout);
-  ui->editKeepAlive->setText(str);
+  m_client.setResponseTimeout(timeout);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -319,7 +312,9 @@ CDlgConnSettingsRawMqtt::getKeepAlive(void)
 void
 CDlgConnSettingsRawMqtt::setKeepAlive(uint32_t timeout)
 {
-  m_client.setResponseTimeout(timeout);
+  vscpworks* pworks = (vscpworks*)QCoreApplication::instance();
+  QString str       = pworks->decimalToStringInBase(timeout, 10);
+  ui->editKeepAlive->setText(str);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -369,7 +364,7 @@ CDlgConnSettingsRawMqtt::enableTLS(bool btls)
 bool
 CDlgConnSettingsRawMqtt::isVerifyPeerEnabled(void)
 {
-  return m_bTLS;
+  return m_bVerifyPeer;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -490,11 +485,11 @@ json
 CDlgConnSettingsRawMqtt::getJson(void)
 {
   m_jsonConfig["type"]               = static_cast<int>(CVscpClient::connType::RAWMQTT);
-  m_jsonConfig["name"]               = getName();
-  m_jsonConfig["host"]               = getBroker();
+  m_jsonConfig["name"]               = getName().toStdString();
+  m_jsonConfig["host"]               = getBroker().toStdString();
   m_jsonConfig["port"]               = getPort();
-  m_jsonConfig["user"]               = getUser();
-  m_jsonConfig["password"]           = getPassword();
+  m_jsonConfig["user"]               = getUser().toStdString();
+  m_jsonConfig["password"]           = getPassword().toStdString();
   m_jsonConfig["connection-timeout"] = (int)getConnectionTimeout();
   m_jsonConfig["response-timeout"]   = (int)getResponseTimeout();
   m_jsonConfig["keepalive"]          = (int)getKeepAlive();
@@ -512,12 +507,12 @@ CDlgConnSettingsRawMqtt::getJson(void)
   json subscriptionArray = json::array();
  
   for (int i = 0; i < ui->listSubscribe->count(); i++) {
-    json obj;
+    json j;
     SubscribeItem* pitem = (SubscribeItem*)ui->listSubscribe->item(i);
-    obj["topic"]         = pitem->getTopic();
-    obj["format"]        = pitem->getFormatInt();
-    obj["qos"]           = pitem->getQos();
-    subscriptionArray.append(obj);
+    j["topic"]           = pitem->getTopic().toStdString();
+    j["format"]          = pitem->getFormatInt();
+    j["qos"]             = pitem->getQos();
+    subscriptionArray.push_back(j);
   }
   m_jsonConfig["subscriptions"] = subscriptionArray;
 
@@ -525,13 +520,13 @@ CDlgConnSettingsRawMqtt::getJson(void)
   json publishingArray = json::array();
   
   for (int i = 0; i < ui->listPublish->count(); i++) {
-    json obj;
+    json j;
     PublishItem* pitem = (PublishItem*)ui->listPublish->item(i);
-    obj["topic"]       = pitem->getTopic();
-    obj["format"]      = pitem->getFormatInt();
-    obj["qos"]         = pitem->getQos();
-    obj["bretain"]     = pitem->getRetain();
-    publishingArray.append(obj);
+    j["topic"]         = pitem->getTopic().toStdString();
+    j["format"]        = pitem->getFormatInt();
+    j["qos"]           = pitem->getQos();
+    j["bretain"]       = pitem->getRetain();
+    publishingArray.push_back(j);
   }
   m_jsonConfig["publishing"] = publishingArray;
 
@@ -547,51 +542,71 @@ CDlgConnSettingsRawMqtt::setJson(const json* pobj)
 {
   m_jsonConfig = *pobj;
 
-  if (!m_jsonConfig["name"].isNull())
-    setName(m_jsonConfig["name"].toString());
-  if (!m_jsonConfig["host"].isNull())
-    setBroker(m_jsonConfig["host"].toString());
-  if (!m_jsonConfig["port"].isNull())
-    setPort((short)m_jsonConfig["port"].toInt());
-  if (!m_jsonConfig["user"].isNull())
-    setUser(m_jsonConfig["user"].toString());
-  if (!m_jsonConfig["password"].isNull())
-    setPassword(m_jsonConfig["password"].toString());
-  if (!m_jsonConfig["connection-timeout"].isNull())
-    setConnectionTimeout(
-      (uint32_t)m_jsonConfig["connection-timeout"].toInt());
-  if (!m_jsonConfig["response-timeout"].isNull())
-    setResponseTimeout((uint32_t)m_jsonConfig["response-timeout"].toInt());
-  if (!m_jsonConfig["keepalive"].isNull())
-    setKeepAlive((uint32_t)m_jsonConfig["keepalive"].toInt());
-  if (!m_jsonConfig["extended-security"].isNull())
-    enableExtendedSecurity(m_jsonConfig["extended-security"].toBool());
+  if (m_jsonConfig.contains("name") && m_jsonConfig["name"].is_string()) {
+    setName(m_jsonConfig["name"].get<std::string>().c_str());
+  }
+  if (m_jsonConfig.contains("host") && m_jsonConfig["host"].is_string()) {
+    setBroker(m_jsonConfig["host"].get<std::string>().c_str());
+  }
+  if (m_jsonConfig.contains("port") && m_jsonConfig["port"].is_number()) {
+    setPort((short)m_jsonConfig["port"].get<int>());
+  }
+  if (m_jsonConfig.contains("user") && m_jsonConfig["user"].is_string()) {
+    setUser(m_jsonConfig["user"].get<std::string>().c_str());
+  }
+  if (m_jsonConfig.contains("password") && m_jsonConfig["password"].is_string()) {
+    setPassword(m_jsonConfig["password"].get<std::string>().c_str());
+  }
+  if (m_jsonConfig.contains("connection-timeout") && m_jsonConfig["connection-timeout"].is_number()) {
+    setConnectionTimeout(m_jsonConfig["connection-timeout"].get<uint32_t>());
+  }
+  if (m_jsonConfig.contains("response-timeout") && m_jsonConfig["response-timeout"].is_number()) {
+    setResponseTimeout(m_jsonConfig["response-timeout"].get<uint32_t>());
+  }
+  if (m_jsonConfig.contains("keepalive") && m_jsonConfig["keepalive"].is_number()) {
+    setKeepAlive(m_jsonConfig["keepalive"].get<uint32_t>());
+  }
+  if (m_jsonConfig.contains("extended-security") && m_jsonConfig["extended-security"].is_boolean()) {
+    enableExtendedSecurity(m_jsonConfig["extended-security"].get<bool>());
+  }
 
-  if (!m_jsonConfig["btls"].isNull())
-    enableTLS((short)m_jsonConfig["btls"].toBool());
-  if (!m_jsonConfig["bverifypeer"].isNull())
-    enableVerifyPeer(m_jsonConfig["bverifypeer"].toBool());
-  if (!m_jsonConfig["cafile"].isNull())
-    setCaFile(m_jsonConfig["cafile"].toString());
-  if (!m_jsonConfig["capath"].isNull())
-    setCaPath(m_jsonConfig["capath"].toString());
-  if (!m_jsonConfig["certfile"].isNull())
-    setCertFile(m_jsonConfig["certfile"].toString());
-  if (!m_jsonConfig["keyfile"].isNull())
-    setKeyFile(m_jsonConfig["keyfile"].toString());
-  if (!m_jsonConfig["pwkeyfile"].isNull())
-    setPwKeyFile(m_jsonConfig["pwkeyfile"].toString());
+  if (m_jsonConfig.contains("btls") && m_jsonConfig["btls"].is_boolean()) {
+    enableTLS((short)m_jsonConfig["btls"].get<bool>());
+  }
+  if (m_jsonConfig.contains("bverifypeer") && m_jsonConfig["bverifypeer"].is_boolean()) {
+    enableVerifyPeer(m_jsonConfig["bverifypeer"].get<bool>());
+  }
+  if (m_jsonConfig.contains("cafile") && m_jsonConfig["cafile"].is_string()) {
+    setCaFile(m_jsonConfig["cafile"].get<std::string>().c_str());
+  }
+  if (m_jsonConfig.contains("capath") && m_jsonConfig["capath"].is_string()) {
+    setCaPath(m_jsonConfig["capath"].get<std::string>().c_str());
+  }
+  if (m_jsonConfig.contains("certfile") && m_jsonConfig["certfile"].is_string()) {
+    setCertFile(m_jsonConfig["certfile"].get<std::string>().c_str());
+  }
+  if (m_jsonConfig.contains("keyfile") && m_jsonConfig["keyfile"].is_string()) {
+    setKeyFile(m_jsonConfig["keyfile"].get<std::string>().c_str());
+  }
+  if (m_jsonConfig.contains("pwkeyfile") && m_jsonConfig["pwkeyfile"].is_string()) {
+    setPwKeyFile(m_jsonConfig["pwkeyfile"].get<std::string>().c_str());
+  }
 
   // Subscriptions
-  if (m_jsonConfig["subscriptions"].isArray()) {
-    json interfacesArray = m_jsonConfig["subscriptions"];
+  if (m_jsonConfig.contains("subscriptions") && m_jsonConfig["subscriptions"].is_array()) {
+    json subscriptions = m_jsonConfig["subscriptions"];
 
-    for (auto v : interfacesArray) {
+    for (const auto& item : subscriptions) {
 
-      json item = v.toObject();
-      if (!item["topic"].isNull()) {
-        SubscribeItem* pitem =
-          new SubscribeItem(item["topic"].toString());
+      if (item.contains("topic") && item["topic"].is_string()) {
+        auto* pitem =
+          new SubscribeItem(item["topic"].get<std::string>().c_str());
+        if (item.contains("format") && item["format"].is_number_integer()) {
+          pitem->setFormatFromInt(item["format"].get<int>());
+        }
+        if (item.contains("qos") && item["qos"].is_number_integer()) {
+          pitem->setQos(item["qos"].get<int>());
+        }
         ui->listSubscribe->addItem(pitem);
       }
     }
@@ -600,19 +615,20 @@ CDlgConnSettingsRawMqtt::setJson(const json* pobj)
   }
 
   // Publish
-  if (m_jsonConfig["publishing"].isArray()) {
-    json interfacesArray = m_jsonConfig["publishing"];
+  if (m_jsonConfig.contains("publishing") && m_jsonConfig["publishing"].is_array()) {
+    json publishing = m_jsonConfig["publishing"];
 
-    for (auto v : interfacesArray) {
+    for (const auto& item : publishing) {
 
-      json item = v.toObject();
-      if (!item["topic"].isNull() && !item["format"].isNull() &&
-          !item["qos"].isNull() && !item["bretain"].isNull()) {
+      if (item.contains("topic") && item["topic"].is_string() &&
+          item.contains("format") && item["format"].is_number_integer() &&
+          item.contains("qos") && item["qos"].is_number_integer() &&
+          item.contains("bretain") && item["bretain"].is_boolean()) {
         PublishItem* pitem = new PublishItem(
-          item["topic"].toString(),
-          static_cast<enumMqttMsgFormat>(item["format"].toInt()),
-          item["qos"].toInt(),
-          item["bretain"].toBool());
+          item["topic"].get<std::string>().c_str(),
+          static_cast<enumMqttMsgFormat>(item["format"].get<int>()),
+          item["qos"].get<int>(),
+          item["bretain"].get<bool>());
         ui->listPublish->addItem(pitem);
       }
     }

--- a/src/cfrmmqttexplorer.cpp
+++ b/src/cfrmmqttexplorer.cpp
@@ -1,0 +1,891 @@
+#include "cfrmmqttexplorer.h"
+
+#include <mosquitto.h>
+
+#include <QApplication>
+#include <QAbstractItemView>
+#include <QByteArray>
+#include <QCheckBox>
+#include <QClipboard>
+#include <QComboBox>
+#include <QDateTime>
+#include <QDir>
+#include <QFile>
+#include <QFileDialog>
+#include <QGridLayout>
+#include <QGroupBox>
+#include <QHBoxLayout>
+#include <QJsonDocument>
+#include <QJsonParseError>
+#include <QLabel>
+#include <QLineEdit>
+#include <QMessageBox>
+#include <QMetaObject>
+#include <QPlainTextEdit>
+#include <QPushButton>
+#include <QSplitter>
+#include <QTreeWidget>
+#include <QTreeWidgetItem>
+#include <QUuid>
+#include <QUrl>
+#include <QVBoxLayout>
+#include <QXmlStreamReader>
+
+#include <algorithm>
+
+namespace {
+
+QString trimmedTopic(const QString& topic)
+{
+  return topic.trimmed();
+}
+
+} // namespace
+
+CFrmMqttExplorer::CFrmMqttExplorer(QWidget* parent, json* pconn)
+  : QDialog(parent)
+  , m_mosq(nullptr)
+  , m_connected(false)
+  , m_tlsEnabled(false)
+  , m_verifyPeer(true)
+  , m_port(1883)
+  , m_keepAlive(60)
+{
+  if (nullptr != pconn) {
+    m_conn = *pconn;
+  }
+
+  setupUi();
+  configureFromConnection();
+  connectToBroker();
+}
+
+CFrmMqttExplorer::~CFrmMqttExplorer()
+{
+  disconnectFromBroker();
+}
+
+void
+CFrmMqttExplorer::setupUi()
+{
+  setAttribute(Qt::WA_DeleteOnClose, true);
+  setWindowTitle(tr("MQTT Explorer"));
+  resize(1200, 760);
+
+  auto* mainLayout = new QVBoxLayout(this);
+
+  auto* connBox    = new QGroupBox(tr("Connection"), this);
+  auto* connLayout = new QHBoxLayout(connBox);
+  m_lblStatus      = new QLabel(tr("Disconnected"), connBox);
+  m_btnConnect     = new QPushButton(tr("Connect"), connBox);
+  connLayout->addWidget(m_lblStatus, 1);
+  connLayout->addWidget(m_btnConnect);
+  mainLayout->addWidget(connBox);
+
+  auto* subscribeBox    = new QGroupBox(tr("Subscribe"), this);
+  auto* subscribeLayout = new QGridLayout(subscribeBox);
+  m_editSubscribeTopic  = new QLineEdit(subscribeBox);
+  m_editSubscribeTopic->setPlaceholderText(tr("Topic (supports + and # wildcards)"));
+  m_comboSubscribeQos = new QComboBox(subscribeBox);
+  m_comboSubscribeQos->addItems({ "0", "1", "2" });
+  m_btnSubscribe   = new QPushButton(tr("Subscribe"), subscribeBox);
+  m_btnUnsubscribe = new QPushButton(tr("Unsubscribe"), subscribeBox);
+  subscribeLayout->addWidget(new QLabel(tr("Topic:"), subscribeBox), 0, 0);
+  subscribeLayout->addWidget(m_editSubscribeTopic, 0, 1);
+  subscribeLayout->addWidget(new QLabel(tr("QoS:"), subscribeBox), 0, 2);
+  subscribeLayout->addWidget(m_comboSubscribeQos, 0, 3);
+  subscribeLayout->addWidget(m_btnSubscribe, 0, 4);
+  subscribeLayout->addWidget(m_btnUnsubscribe, 0, 5);
+  mainLayout->addWidget(subscribeBox);
+
+  auto* publishBox    = new QGroupBox(tr("Publish"), this);
+  auto* publishLayout = new QGridLayout(publishBox);
+  m_editPublishTopic  = new QLineEdit(publishBox);
+  m_editPublishTopic->setPlaceholderText(tr("Topic"));
+  m_comboPublishQos = new QComboBox(publishBox);
+  m_comboPublishQos->addItems({ "0", "1", "2" });
+  m_chkPublishRetain = new QCheckBox(tr("Retain"), publishBox);
+  m_editPublishPayload = new QPlainTextEdit(publishBox);
+  m_editPublishPayload->setPlaceholderText(tr("Payload"));
+  m_btnPublish = new QPushButton(tr("Publish"), publishBox);
+  publishLayout->addWidget(new QLabel(tr("Topic:"), publishBox), 0, 0);
+  publishLayout->addWidget(m_editPublishTopic, 0, 1, 1, 3);
+  publishLayout->addWidget(new QLabel(tr("QoS:"), publishBox), 0, 4);
+  publishLayout->addWidget(m_comboPublishQos, 0, 5);
+  publishLayout->addWidget(m_chkPublishRetain, 0, 6);
+  publishLayout->addWidget(new QLabel(tr("Payload:"), publishBox), 1, 0);
+  publishLayout->addWidget(m_editPublishPayload, 1, 1, 1, 6);
+  publishLayout->addWidget(m_btnPublish, 2, 6);
+  mainLayout->addWidget(publishBox);
+
+  auto* filterLayout = new QHBoxLayout();
+  filterLayout->addWidget(new QLabel(tr("Filter:"), this));
+  m_editFilter = new QLineEdit(this);
+  m_editFilter->setPlaceholderText(tr("Filter by topic or payload"));
+  filterLayout->addWidget(m_editFilter, 1);
+  m_btnCopy = new QPushButton(tr("Copy selected"), this);
+  m_btnSave = new QPushButton(tr("Save selected"), this);
+  filterLayout->addWidget(m_btnCopy);
+  filterLayout->addWidget(m_btnSave);
+  mainLayout->addLayout(filterLayout);
+
+  auto* splitter = new QSplitter(Qt::Horizontal, this);
+  m_tree          = new QTreeWidget(splitter);
+  m_tree->setHeaderLabels({ tr("Topic/Message"), tr("Value") });
+  m_tree->setSelectionMode(QAbstractItemView::SingleSelection);
+  m_tree->setAlternatingRowColors(true);
+  m_tree->setUniformRowHeights(true);
+  m_tree->setExpandsOnDoubleClick(true);
+
+  m_details = new QPlainTextEdit(splitter);
+  m_details->setReadOnly(true);
+  splitter->setStretchFactor(0, 3);
+  splitter->setStretchFactor(1, 2);
+  mainLayout->addWidget(splitter, 1);
+
+  connect(m_btnConnect,
+          &QPushButton::clicked,
+          this,
+          &CFrmMqttExplorer::onConnectClicked);
+  connect(m_btnPublish,
+          &QPushButton::clicked,
+          this,
+          &CFrmMqttExplorer::onPublishClicked);
+  connect(m_btnSubscribe,
+          &QPushButton::clicked,
+          this,
+          &CFrmMqttExplorer::onSubscribeClicked);
+  connect(m_btnUnsubscribe,
+          &QPushButton::clicked,
+          this,
+          &CFrmMqttExplorer::onUnsubscribeClicked);
+  connect(m_editFilter,
+          &QLineEdit::textChanged,
+          this,
+          &CFrmMqttExplorer::onFilterChanged);
+  connect(m_tree,
+          &QTreeWidget::itemSelectionChanged,
+          this,
+          &CFrmMqttExplorer::onTreeSelectionChanged);
+  connect(m_btnCopy, &QPushButton::clicked, this, &CFrmMqttExplorer::onCopySelected);
+  connect(m_btnSave, &QPushButton::clicked, this, &CFrmMqttExplorer::onSaveSelected);
+}
+
+void
+CFrmMqttExplorer::configureFromConnection()
+{
+  if (m_conn.contains("name") && m_conn["name"].is_string()) {
+    setWindowTitle(tr("MQTT Explorer - %1")
+                     .arg(QString::fromStdString(m_conn["name"].get<std::string>())));
+  }
+
+  m_host = "localhost";
+  if (m_conn.contains("host") && m_conn["host"].is_string()) {
+    m_host = QString::fromStdString(m_conn["host"].get<std::string>());
+  }
+
+  if (m_conn.contains("port") && m_conn["port"].is_number_integer()) {
+    m_port = m_conn["port"].get<int>();
+  }
+
+  if (m_conn.contains("keepalive") && m_conn["keepalive"].is_number_integer()) {
+    m_keepAlive = std::max(0, m_conn["keepalive"].get<int>());
+  }
+
+  if (m_conn.contains("clientid") && m_conn["clientid"].is_string()) {
+    m_clientId = QString::fromStdString(m_conn["clientid"].get<std::string>());
+  }
+  if (m_clientId.isEmpty()) {
+    m_clientId = QString("vscpworks-explorer-%1").arg(QUuid::createUuid().toString(QUuid::WithoutBraces));
+  }
+
+  if (m_conn.contains("user") && m_conn["user"].is_string()) {
+    m_user = QString::fromStdString(m_conn["user"].get<std::string>());
+  }
+  if (m_conn.contains("password") && m_conn["password"].is_string()) {
+    m_password = QString::fromStdString(m_conn["password"].get<std::string>());
+  }
+
+  if (m_conn.contains("btls") && m_conn["btls"].is_boolean()) {
+    m_tlsEnabled = m_conn["btls"].get<bool>();
+  }
+  if (m_conn.contains("bverifypeer") && m_conn["bverifypeer"].is_boolean()) {
+    m_verifyPeer = m_conn["bverifypeer"].get<bool>();
+  }
+  if (m_conn.contains("cafile") && m_conn["cafile"].is_string()) {
+    m_cafile = QString::fromStdString(m_conn["cafile"].get<std::string>());
+  }
+  if (m_conn.contains("capath") && m_conn["capath"].is_string()) {
+    m_capath = QString::fromStdString(m_conn["capath"].get<std::string>());
+  }
+  if (m_conn.contains("certfile") && m_conn["certfile"].is_string()) {
+    m_certfile = QString::fromStdString(m_conn["certfile"].get<std::string>());
+  }
+  if (m_conn.contains("keyfile") && m_conn["keyfile"].is_string()) {
+    m_keyfile = QString::fromStdString(m_conn["keyfile"].get<std::string>());
+  }
+  if (m_conn.contains("pwkeyfile") && m_conn["pwkeyfile"].is_string()) {
+    m_pwkeyfile = QString::fromStdString(m_conn["pwkeyfile"].get<std::string>());
+  }
+
+  const QUrl url(m_host);
+  if (url.isValid() && !url.scheme().isEmpty() && !url.host().isEmpty()) {
+    m_host = url.host();
+    if (url.port() > 0) {
+      m_port = url.port();
+    }
+    if (!m_conn.contains("btls") && (url.scheme() == "mqtts" || url.scheme() == "ssl")) {
+      m_tlsEnabled = true;
+    }
+  }
+
+  if (m_tlsEnabled && m_port == 1883 && !m_conn.contains("port")) {
+    m_port = 8883;
+  }
+
+  if (m_conn.contains("subscribe") && m_conn["subscribe"].is_array()) {
+    for (const auto& entry : m_conn["subscribe"]) {
+      if (entry.contains("topic") && entry["topic"].is_string()) {
+        m_initialSubscriptions.insert(
+          QString::fromStdString(entry["topic"].get<std::string>()));
+      }
+    }
+  }
+  if (m_conn.contains("subscriptions") && m_conn["subscriptions"].is_array()) {
+    for (const auto& entry : m_conn["subscriptions"]) {
+      if (entry.contains("topic") && entry["topic"].is_string()) {
+        m_initialSubscriptions.insert(
+          QString::fromStdString(entry["topic"].get<std::string>()));
+      }
+    }
+  }
+}
+
+bool
+CFrmMqttExplorer::connectToBroker()
+{
+  disconnectFromBroker();
+
+  mosquitto_lib_init();
+  m_mosq = mosquitto_new(m_clientId.toUtf8().constData(), true, this);
+  if (nullptr == m_mosq) {
+    setStatus(tr("Failed to create MQTT client"), true);
+    return false;
+  }
+
+  mosquitto_connect_callback_set(m_mosq, &CFrmMqttExplorer::onMosquittoConnectStatic);
+  mosquitto_disconnect_callback_set(m_mosq,
+                                    &CFrmMqttExplorer::onMosquittoDisconnectStatic);
+  mosquitto_message_callback_set(m_mosq, &CFrmMqttExplorer::onMosquittoMessageStatic);
+
+  if (!m_user.isEmpty()) {
+    const int rc = mosquitto_username_pw_set(m_mosq,
+                                             m_user.toUtf8().constData(),
+                                             m_password.toUtf8().constData());
+    if (MOSQ_ERR_SUCCESS != rc) {
+      setStatus(tr("Failed to set username/password: %1")
+                  .arg(QString::fromUtf8(mosquitto_strerror(rc))),
+                true);
+      disconnectFromBroker();
+      return false;
+    }
+  }
+
+  if (m_tlsEnabled) {
+    applyTlsSettings();
+  }
+
+  const int loopRc = mosquitto_loop_start(m_mosq);
+  if (MOSQ_ERR_SUCCESS != loopRc) {
+    setStatus(tr("Failed to start MQTT loop: %1")
+                .arg(QString::fromUtf8(mosquitto_strerror(loopRc))),
+              true);
+    disconnectFromBroker();
+    return false;
+  }
+
+  const int connectRc =
+    mosquitto_connect_async(m_mosq, m_host.toUtf8().constData(), m_port, std::max(5, m_keepAlive));
+  if (MOSQ_ERR_SUCCESS != connectRc) {
+    setStatus(tr("Failed to connect to %1:%2 - %3")
+                .arg(m_host)
+                .arg(m_port)
+                .arg(QString::fromUtf8(mosquitto_strerror(connectRc))),
+              true);
+    disconnectFromBroker();
+    return false;
+  }
+
+  setStatus(tr("Connecting to %1:%2 ...").arg(m_host).arg(m_port));
+  m_btnConnect->setText(tr("Disconnect"));
+  return true;
+}
+
+void
+CFrmMqttExplorer::disconnectFromBroker()
+{
+  if (nullptr != m_mosq) {
+    mosquitto_disconnect(m_mosq);
+    mosquitto_loop_stop(m_mosq, false);
+    mosquitto_destroy(m_mosq);
+    m_mosq = nullptr;
+  }
+
+  m_connected = false;
+  m_btnConnect->setText(tr("Connect"));
+}
+
+bool
+CFrmMqttExplorer::isConnected() const
+{
+  return m_connected && (nullptr != m_mosq);
+}
+
+void
+CFrmMqttExplorer::onConnectClicked()
+{
+  if (isConnected()) {
+    disconnectFromBroker();
+    setStatus(tr("Disconnected"));
+    return;
+  }
+
+  connectToBroker();
+}
+
+bool
+CFrmMqttExplorer::subscribeTopic(const QString& topic, int qos)
+{
+  const QString t = trimmedTopic(topic);
+  if (t.isEmpty() || nullptr == m_mosq) {
+    return false;
+  }
+
+  const int rc = mosquitto_subscribe(m_mosq, nullptr, t.toUtf8().constData(), qos);
+  if (MOSQ_ERR_SUCCESS != rc) {
+    setStatus(tr("Subscribe failed for '%1': %2")
+                .arg(t)
+                .arg(QString::fromUtf8(mosquitto_strerror(rc))),
+              true);
+    return false;
+  }
+
+  m_subscriptions.insert(t);
+  setStatus(tr("Subscribed to '%1'").arg(t));
+  return true;
+}
+
+bool
+CFrmMqttExplorer::unsubscribeTopic(const QString& topic)
+{
+  const QString t = trimmedTopic(topic);
+  if (t.isEmpty() || nullptr == m_mosq) {
+    return false;
+  }
+
+  const int rc = mosquitto_unsubscribe(m_mosq, nullptr, t.toUtf8().constData());
+  if (MOSQ_ERR_SUCCESS != rc) {
+    setStatus(tr("Unsubscribe failed for '%1': %2")
+                .arg(t)
+                .arg(QString::fromUtf8(mosquitto_strerror(rc))),
+              true);
+    return false;
+  }
+
+  m_subscriptions.remove(t);
+  setStatus(tr("Unsubscribed from '%1'").arg(t));
+  return true;
+}
+
+bool
+CFrmMqttExplorer::publishMessage(const QString& topic,
+                                 const QByteArray& payload,
+                                 int qos,
+                                 bool retain)
+{
+  const QString t = trimmedTopic(topic);
+  if (t.isEmpty() || nullptr == m_mosq) {
+    return false;
+  }
+
+  const int rc = mosquitto_publish(m_mosq,
+                                   nullptr,
+                                   t.toUtf8().constData(),
+                                   payload.size(),
+                                   payload.constData(),
+                                   qos,
+                                   retain);
+  if (MOSQ_ERR_SUCCESS != rc) {
+    setStatus(tr("Publish failed for '%1': %2")
+                .arg(t)
+                .arg(QString::fromUtf8(mosquitto_strerror(rc))),
+              true);
+    return false;
+  }
+
+  setStatus(tr("Published to '%1'").arg(t));
+  return true;
+}
+
+void
+CFrmMqttExplorer::onPublishClicked()
+{
+  if (!isConnected()) {
+    setStatus(tr("Not connected"), true);
+    return;
+  }
+
+  if (!publishMessage(m_editPublishTopic->text(),
+                      m_editPublishPayload->toPlainText().toUtf8(),
+                      m_comboPublishQos->currentText().toInt(),
+                      m_chkPublishRetain->isChecked())) {
+    return;
+  }
+}
+
+void
+CFrmMqttExplorer::onSubscribeClicked()
+{
+  if (!isConnected()) {
+    setStatus(tr("Not connected"), true);
+    return;
+  }
+
+  subscribeTopic(m_editSubscribeTopic->text(), m_comboSubscribeQos->currentText().toInt());
+}
+
+void
+CFrmMqttExplorer::onUnsubscribeClicked()
+{
+  if (!isConnected()) {
+    setStatus(tr("Not connected"), true);
+    return;
+  }
+
+  QString topic = trimmedTopic(m_editSubscribeTopic->text());
+  if (topic.isEmpty()) {
+    const auto selected = m_tree->selectedItems();
+    if (!selected.isEmpty()) {
+      topic = selected.first()->data(0, RoleTopic).toString();
+    }
+  }
+
+  if (topic.isEmpty()) {
+    setStatus(tr("No topic selected"), true);
+    return;
+  }
+
+  unsubscribeTopic(topic);
+}
+
+QTreeWidgetItem*
+CFrmMqttExplorer::ensureTopicPath(const QString& topic)
+{
+  QString normalized = topic;
+  if (normalized.isEmpty()) {
+    normalized = "/";
+  }
+
+  if (m_topicNodeByPath.contains(normalized)) {
+    return m_topicNodeByPath.value(normalized);
+  }
+
+  const QStringList parts = normalized.split('/', Qt::KeepEmptyParts);
+  QString currentPath;
+  QTreeWidgetItem* parent = nullptr;
+
+  for (int i = 0; i < parts.size(); ++i) {
+    const QString segment = parts.at(i).isEmpty() ? "/" : parts.at(i);
+    currentPath = currentPath.isEmpty() ? segment : currentPath + "/" + segment;
+
+    if (!m_topicNodeByPath.contains(currentPath)) {
+      auto* item = new QTreeWidgetItem({ segment, "" });
+      item->setData(0, RoleKind, KindTopicNode);
+      item->setData(0, RoleTopic, normalized);
+      item->setData(0, RoleSearchText, currentPath.toLower());
+      if (nullptr == parent) {
+        m_tree->addTopLevelItem(item);
+      }
+      else {
+        parent->addChild(item);
+      }
+      m_topicNodeByPath.insert(currentPath, item);
+    }
+    parent = m_topicNodeByPath.value(currentPath);
+  }
+
+  m_topicNodeByPath.insert(normalized, parent);
+  return parent;
+}
+
+void
+CFrmMqttExplorer::updateTopicNodeWithMessage(QTreeWidgetItem* topicNode,
+                                             const QString& topic,
+                                             const QByteArray& payload,
+                                             const QString& formattedPayload)
+{
+  if (nullptr == topicNode) {
+    return;
+  }
+
+  const QString payloadText = QString::fromUtf8(payload);
+  topicNode->setText(1, payloadText.left(120).replace('\n', " "));
+  topicNode->setData(0, RolePayloadRaw, payloadText);
+  topicNode->setData(0, RolePayloadFormatted, formattedPayload);
+  topicNode->setData(0,
+                     RoleSearchText,
+                     buildSearchText(topic, payload, formattedPayload).toLower());
+}
+
+void
+CFrmMqttExplorer::appendMessageNode(QTreeWidgetItem* topicNode,
+                                    const QString& topic,
+                                    const QByteArray& payload,
+                                    const QString& formattedPayload,
+                                    bool retained)
+{
+  if (nullptr == topicNode) {
+    return;
+  }
+
+  const QString timestamp = QDateTime::currentDateTime().toString("yyyy-MM-dd HH:mm:ss.zzz");
+  const QString preview =
+    QString::fromUtf8(payload).left(120).replace('\n', " ").replace('\r', " ");
+  auto* msgItem = new QTreeWidgetItem({ timestamp + (retained ? " [R]" : ""), preview });
+  msgItem->setData(0, RoleKind, KindMessage);
+  msgItem->setData(0, RoleTopic, topic);
+  msgItem->setData(0, RolePayloadRaw, QString::fromUtf8(payload));
+  msgItem->setData(0, RolePayloadFormatted, formattedPayload);
+  msgItem->setData(0,
+                   RoleSearchText,
+                   buildSearchText(topic, payload, formattedPayload).toLower());
+  topicNode->addChild(msgItem);
+  topicNode->setExpanded(true);
+
+  constexpr int kMaxMessagesPerTopic = 500;
+  while (topicNode->childCount() > kMaxMessagesPerTopic) {
+    delete topicNode->takeChild(0);
+  }
+}
+
+QString
+CFrmMqttExplorer::formatPayloadForDisplay(const QByteArray& payload,
+                                          QString* outFormat) const
+{
+  const QString raw = QString::fromUtf8(payload);
+  const QString trimmed = raw.trimmed();
+
+  QJsonParseError jsonErr;
+  const auto jsonDoc = QJsonDocument::fromJson(payload, &jsonErr);
+  if (QJsonParseError::NoError == jsonErr.error &&
+      (jsonDoc.isObject() || jsonDoc.isArray())) {
+    if (nullptr != outFormat) {
+      *outFormat = tr("JSON");
+    }
+    return QString::fromUtf8(jsonDoc.toJson(QJsonDocument::Indented));
+  }
+
+  if (trimmed.startsWith('<') && trimmed.endsWith('>')) {
+    const QString xmlDisplay = buildXmlDisplay(trimmed);
+    if (!xmlDisplay.isEmpty()) {
+      if (nullptr != outFormat) {
+        *outFormat = tr("XML");
+      }
+      return xmlDisplay;
+    }
+  }
+
+  if (nullptr != outFormat) {
+    *outFormat = tr("Text");
+  }
+  return raw;
+}
+
+QString
+CFrmMqttExplorer::buildXmlDisplay(const QString& xml) const
+{
+  QXmlStreamReader reader(xml);
+  QString out;
+  int depth = 0;
+
+  while (!reader.atEnd()) {
+    reader.readNext();
+    if (reader.isStartElement()) {
+      out += QString(depth * 2, ' ') + "<" + reader.name().toString();
+      const auto attrs = reader.attributes();
+      for (const auto& attr : attrs) {
+        out += " " + attr.name().toString() + "=\"" + attr.value().toString() + "\"";
+      }
+      out += ">\n";
+      ++depth;
+    }
+    else if (reader.isEndElement()) {
+      depth = std::max(0, depth - 1);
+      out += QString(depth * 2, ' ') + "</" + reader.name().toString() + ">\n";
+    }
+    else if (reader.isCharacters() && !reader.isWhitespace()) {
+      out += QString(depth * 2, ' ') + reader.text().toString() + "\n";
+    }
+  }
+
+  if (reader.hasError()) {
+    return QString();
+  }
+
+  return out.trimmed();
+}
+
+QString
+CFrmMqttExplorer::buildSearchText(const QString& topic,
+                                  const QByteArray& payload,
+                                  const QString& formatted) const
+{
+  return topic + "\n" + QString::fromUtf8(payload) + "\n" + formatted;
+}
+
+bool
+CFrmMqttExplorer::applyFilterRecursive(QTreeWidgetItem* item, const QString& filterLower)
+{
+  if (nullptr == item) {
+    return false;
+  }
+
+  bool visible = filterLower.isEmpty();
+  const QString search = item->data(0, RoleSearchText).toString();
+  if (!filterLower.isEmpty() && search.contains(filterLower, Qt::CaseInsensitive)) {
+    visible = true;
+  }
+
+  for (int i = 0; i < item->childCount(); ++i) {
+    visible = applyFilterRecursive(item->child(i), filterLower) || visible;
+  }
+
+  item->setHidden(!visible);
+  return visible;
+}
+
+void
+CFrmMqttExplorer::onFilterChanged(const QString& filter)
+{
+  const QString lower = filter.trimmed().toLower();
+  for (int i = 0; i < m_tree->topLevelItemCount(); ++i) {
+    applyFilterRecursive(m_tree->topLevelItem(i), lower);
+  }
+}
+
+void
+CFrmMqttExplorer::onTreeSelectionChanged()
+{
+  const auto selected = m_tree->selectedItems();
+  if (selected.isEmpty()) {
+    m_details->clear();
+    return;
+  }
+
+  auto* item = selected.first();
+  const QString topic = item->data(0, RoleTopic).toString();
+  const QString raw = item->data(0, RolePayloadRaw).toString();
+  const QString formatted = item->data(0, RolePayloadFormatted).toString();
+  const int kind = item->data(0, RoleKind).toInt();
+
+  QString text;
+  text += tr("Topic: %1\n").arg(topic);
+  if (KindMessage == kind) {
+    text += tr("Type: Message\n");
+  }
+  else {
+    text += tr("Type: Topic node\n");
+  }
+  text += "\n";
+  if (!formatted.isEmpty()) {
+    text += tr("Decoded payload:\n");
+    text += formatted;
+    text += "\n\n";
+  }
+  if (!raw.isEmpty()) {
+    text += tr("Raw payload:\n");
+    text += raw;
+  }
+
+  m_details->setPlainText(text.trimmed());
+}
+
+void
+CFrmMqttExplorer::onCopySelected()
+{
+  const QString text = m_details->toPlainText();
+  if (text.isEmpty()) {
+    return;
+  }
+  QApplication::clipboard()->setText(text);
+}
+
+void
+CFrmMqttExplorer::onSaveSelected()
+{
+  const QString text = m_details->toPlainText();
+  if (text.isEmpty()) {
+    return;
+  }
+
+  const QString path = QFileDialog::getSaveFileName(this,
+                                                    tr("Save selected MQTT data"),
+                                                    QDir::homePath() + "/mqtt-data.txt",
+                                                    tr("Text files (*.txt);;All files (*)"));
+  if (path.isEmpty()) {
+    return;
+  }
+
+  QFile file(path);
+  if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+    QMessageBox::warning(this,
+                         tr("MQTT Explorer"),
+                         tr("Failed to save selected data to '%1'.").arg(path));
+    return;
+  }
+
+  file.write(text.toUtf8());
+  file.close();
+}
+
+void
+CFrmMqttExplorer::setStatus(const QString& status, bool error)
+{
+  m_lblStatus->setText(status);
+  m_lblStatus->setStyleSheet(error ? "QLabel { color: #c62828; }"
+                                   : "QLabel { color: palette(window-text); }");
+}
+
+void
+CFrmMqttExplorer::applyTlsSettings()
+{
+  if (nullptr == m_mosq) {
+    return;
+  }
+
+  const QByteArray cafile = m_cafile.toUtf8();
+  const QByteArray capath = m_capath.toUtf8();
+  const QByteArray certfile = m_certfile.toUtf8();
+  const QByteArray keyfile = m_keyfile.toUtf8();
+  const int tlsRc = mosquitto_tls_set(m_mosq,
+                                      cafile.isEmpty() ? nullptr : cafile.constData(),
+                                      capath.isEmpty() ? nullptr : capath.constData(),
+                                      certfile.isEmpty() ? nullptr : certfile.constData(),
+                                      keyfile.isEmpty() ? nullptr : keyfile.constData(),
+                                      nullptr);
+  if (MOSQ_ERR_SUCCESS != tlsRc) {
+    setStatus(tr("TLS setup failed: %1")
+                .arg(QString::fromUtf8(mosquitto_strerror(tlsRc))),
+              true);
+  }
+
+  mosquitto_tls_opts_set(m_mosq, m_verifyPeer ? 1 : 0, nullptr, nullptr);
+
+  mosquitto_tls_insecure_set(m_mosq, m_verifyPeer ? false : true);
+}
+
+void
+CFrmMqttExplorer::subscribeConfiguredTopics()
+{
+  for (const auto& topic : m_initialSubscriptions) {
+    if (!topic.trimmed().isEmpty()) {
+      subscribeTopic(topic, 0);
+    }
+  }
+}
+
+void
+CFrmMqttExplorer::handleConnected(int rc)
+{
+  if (0 == rc) {
+    m_connected = true;
+    setStatus(tr("Connected to %1:%2").arg(m_host).arg(m_port));
+    subscribeConfiguredTopics();
+    return;
+  }
+
+  m_connected = false;
+  m_btnConnect->setText(tr("Connect"));
+  setStatus(tr("Connect failed: %1").arg(QString::fromUtf8(mosquitto_connack_string(rc))),
+            true);
+}
+
+void
+CFrmMqttExplorer::handleDisconnected(int rc)
+{
+  m_connected = false;
+  m_btnConnect->setText(tr("Connect"));
+  if (0 == rc) {
+    setStatus(tr("Disconnected"));
+  }
+  else {
+    setStatus(tr("Connection lost: %1").arg(rc), true);
+  }
+}
+
+void
+CFrmMqttExplorer::handleIncomingMessage(const QString& topic,
+                                        const QByteArray& payload,
+                                        bool retained)
+{
+  QString format;
+  const QString formatted = formatPayloadForDisplay(payload, &format);
+
+  QTreeWidgetItem* topicNode = ensureTopicPath(topic);
+  updateTopicNodeWithMessage(topicNode, topic, payload, formatted);
+  appendMessageNode(topicNode, topic, payload, formatted, retained);
+  onFilterChanged(m_editFilter->text());
+
+  if (m_tree->selectedItems().isEmpty()) {
+    m_tree->setCurrentItem(topicNode);
+  }
+}
+
+void
+CFrmMqttExplorer::onMosquittoConnectStatic(struct mosquitto*,
+                                           void* userdata,
+                                           int rc)
+{
+  auto* self = static_cast<CFrmMqttExplorer*>(userdata);
+  if (nullptr == self) {
+    return;
+  }
+  QMetaObject::invokeMethod(self, [self, rc]() { self->handleConnected(rc); }, Qt::QueuedConnection);
+}
+
+void
+CFrmMqttExplorer::onMosquittoDisconnectStatic(struct mosquitto*,
+                                              void* userdata,
+                                              int rc)
+{
+  auto* self = static_cast<CFrmMqttExplorer*>(userdata);
+  if (nullptr == self) {
+    return;
+  }
+  QMetaObject::invokeMethod(self,
+                            [self, rc]() { self->handleDisconnected(rc); },
+                            Qt::QueuedConnection);
+}
+
+void
+CFrmMqttExplorer::onMosquittoMessageStatic(struct mosquitto*,
+                                           void* userdata,
+                                           const struct mosquitto_message* message)
+{
+  auto* self = static_cast<CFrmMqttExplorer*>(userdata);
+  if (nullptr == self || nullptr == message) {
+    return;
+  }
+
+  const QString topic = QString::fromUtf8(message->topic ? message->topic : "");
+  QByteArray payload;
+  if (message->payloadlen > 0 && nullptr != message->payload) {
+    payload = QByteArray(static_cast<const char*>(message->payload), message->payloadlen);
+  }
+  const bool retained = message->retain;
+
+  QMetaObject::invokeMethod(
+    self,
+    [self, topic, payload, retained]() { self->handleIncomingMessage(topic, payload, retained); },
+    Qt::QueuedConnection);
+}

--- a/src/cfrmmqttexplorer.h
+++ b/src/cfrmmqttexplorer.h
@@ -1,0 +1,137 @@
+#ifndef CFRMMQTTEXPLORER_H
+#define CFRMMQTTEXPLORER_H
+
+#include "vscp-client-base.h"
+
+#include <QByteArray>
+#include <QDialog>
+#include <QHash>
+#include <QSet>
+
+struct mosquitto;
+struct mosquitto_message;
+
+class QCheckBox;
+class QComboBox;
+class QLabel;
+class QLineEdit;
+class QPlainTextEdit;
+class QPushButton;
+class QTreeWidget;
+class QTreeWidgetItem;
+
+class CFrmMqttExplorer : public QDialog {
+  Q_OBJECT
+
+public:
+  explicit CFrmMqttExplorer(QWidget* parent, json* pconn);
+  ~CFrmMqttExplorer();
+
+private slots:
+  void onConnectClicked();
+  void onPublishClicked();
+  void onSubscribeClicked();
+  void onUnsubscribeClicked();
+  void onFilterChanged(const QString& filter);
+  void onTreeSelectionChanged();
+  void onCopySelected();
+  void onSaveSelected();
+  void handleConnected(int rc);
+  void handleDisconnected(int rc);
+  void handleIncomingMessage(const QString& topic,
+                             const QByteArray& payload,
+                             bool retained);
+
+private:
+  enum ItemRole {
+    RoleKind = Qt::UserRole + 1,
+    RoleTopic,
+    RolePayloadRaw,
+    RolePayloadFormatted,
+    RoleSearchText
+  };
+
+  enum ItemKind { KindTopicNode = 1, KindMessage = 2 };
+
+  void setupUi();
+  void configureFromConnection();
+  bool connectToBroker();
+  void disconnectFromBroker();
+  bool isConnected() const;
+  bool subscribeTopic(const QString& topic, int qos);
+  bool unsubscribeTopic(const QString& topic);
+  bool publishMessage(const QString& topic,
+                      const QByteArray& payload,
+                      int qos,
+                      bool retain);
+
+  QTreeWidgetItem* ensureTopicPath(const QString& topic);
+  void updateTopicNodeWithMessage(QTreeWidgetItem* topicNode,
+                                  const QString& topic,
+                                  const QByteArray& payload,
+                                  const QString& formattedPayload);
+  void appendMessageNode(QTreeWidgetItem* topicNode,
+                         const QString& topic,
+                         const QByteArray& payload,
+                         const QString& formattedPayload,
+                         bool retained);
+  QString formatPayloadForDisplay(const QByteArray& payload,
+                                  QString* outFormat = nullptr) const;
+  QString buildXmlDisplay(const QString& xml) const;
+  QString buildSearchText(const QString& topic,
+                          const QByteArray& payload,
+                          const QString& formatted) const;
+  bool applyFilterRecursive(QTreeWidgetItem* item, const QString& filterLower);
+  void setStatus(const QString& status, bool error = false);
+  void applyTlsSettings();
+  void subscribeConfiguredTopics();
+
+  static void onMosquittoConnectStatic(struct mosquitto* mosq,
+                                       void* userdata,
+                                       int rc);
+  static void onMosquittoDisconnectStatic(struct mosquitto* mosq,
+                                          void* userdata,
+                                          int rc);
+  static void onMosquittoMessageStatic(struct mosquitto* mosq,
+                                       void* userdata,
+                                       const struct mosquitto_message* message);
+
+  json m_conn;
+  struct mosquitto* m_mosq;
+  bool m_connected;
+  bool m_tlsEnabled;
+  bool m_verifyPeer;
+  QString m_host;
+  int m_port;
+  QString m_clientId;
+  QString m_user;
+  QString m_password;
+  int m_keepAlive;
+  QString m_cafile;
+  QString m_capath;
+  QString m_certfile;
+  QString m_keyfile;
+  QString m_pwkeyfile;
+  QSet<QString> m_subscriptions;
+  QSet<QString> m_initialSubscriptions;
+  QHash<QString, QTreeWidgetItem*> m_topicNodeByPath;
+
+  QPushButton* m_btnConnect;
+  QPushButton* m_btnSubscribe;
+  QPushButton* m_btnUnsubscribe;
+  QPushButton* m_btnPublish;
+  QPushButton* m_btnCopy;
+  QPushButton* m_btnSave;
+  QLineEdit* m_editSubscribeTopic;
+  QComboBox* m_comboSubscribeQos;
+  QLineEdit* m_editPublishTopic;
+  QComboBox* m_comboPublishQos;
+  QCheckBox* m_chkPublishRetain;
+  QPlainTextEdit* m_editPublishPayload;
+  QLineEdit* m_editFilter;
+  QTreeWidget* m_tree;
+  QPlainTextEdit* m_details;
+  QLabel* m_lblStatus;
+};
+
+#endif // CFRMMQTTEXPLORER_H

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -69,6 +69,7 @@
 #include "cfrmnodeconfig.h"
 #include "cfrmnodescan.h"
 #include "cfrmsession.h"
+#include "cfrmmqttexplorer.h"
 #include "cfrmvscplinktest.h"
 #include "filedownloader.h"
 #include "version.h"
@@ -1164,6 +1165,13 @@ MainWindow::showConnectionContextMenu(const QPoint& pos)
                     this,
                     SLOT(newSession()));
 
+    if (static_cast<int>(CVscpClient::connType::MQTT) == item->parent()->type()) {
+      menu->addAction(newSessionIcon,
+                      QString(tr("MQTT Explorer")),
+                      this,
+                      SLOT(newMqttExplorer()));
+    }
+
     const QIcon devConfigIcon = QIcon(":/page_process.png");
     menu->addAction(devConfigIcon,
                     QString(tr("Configuration")),
@@ -1485,6 +1493,16 @@ MainWindow::createActions()
   connect(newSessionAct, &QAction::triggered, this, &MainWindow::newSession);
   fileMenu->addAction(newSessionAct);
   fileToolBar->addAction(newSessionAct);
+
+  QAction* newMqttExplorerAct =
+    new QAction(newSessionIcon, tr("MQTT &Explorer window..."), this);
+  newMqttExplorerAct->setStatusTip(tr("Open a new MQTT Explorer window"));
+  connect(newMqttExplorerAct,
+          &QAction::triggered,
+          this,
+          &MainWindow::newMqttExplorer);
+  fileMenu->addAction(newMqttExplorerAct);
+  fileToolBar->addAction(newMqttExplorerAct);
 
   // Node configuration
   const QIcon newDevConfigIcon = QIcon(":/page_process.png");
@@ -1882,6 +1900,7 @@ MainWindow::newSession()
       // Get the connection object
 
       json* pconn    = itemConn->getJson();
+      const int type = (*pconn)["type"].get<int>();
       CFrmSession* w = new CFrmSession(this, pconn);
       if (!w->isConnected() && (pworks->m_session_bAutoConnect)) {
         delete w;
@@ -1898,6 +1917,47 @@ MainWindow::newSession()
       // eFlags |= Qt::WindowStaysOnTopHint;
       // setWindowFlags(eFlags);
     }
+}
+}
+
+/////////////////////////////////////////////////////////////////////////////////
+// newMqttExplorer
+//
+
+void
+MainWindow::newMqttExplorer()
+{
+  QList<QTreeWidgetItem*> itemList;
+  itemList = m_connTreeTable->selectedItems();
+
+  // If no item is selected then complain
+  if (!itemList.size()) {
+    QMessageBox::warning(this,
+                         tr("VSCP Works+"),
+                         tr("No connection selected.\n"
+                            "Please select a connection first."));
+    return;
+  }
+
+  foreach (QTreeWidgetItem* item, itemList) {
+    if (NULL == item->parent()) {
+      continue;
+    }
+
+    treeWidgetItemConn* itemConn = (treeWidgetItemConn*)item;
+    json* pconn                  = itemConn->getJson();
+    const int type               = (*pconn)["type"].get<int>();
+    if (static_cast<int>(CVscpClient::connType::MQTT) != type) {
+      continue;
+    }
+
+    CFrmMqttExplorer* w = new CFrmMqttExplorer(this, pconn);
+    w->setAttribute(Qt::WA_DeleteOnClose, true);
+    w->setWindowState((windowState() & ~Qt::WindowMinimized) | Qt::WindowActive);
+    w->setWindowFlags(Qt::Window);
+    w->show();
+    w->raise();
+    w->activateWindow();
   }
 }
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -131,6 +131,7 @@ private slots:
     void commitData(QSessionManager &);
 #endif
     void newSession();
+    void newMqttExplorer();
     void newNodeConfiguration();
     void newNodeScan();
     void newNodeBootload();
@@ -231,7 +232,6 @@ private:
   QTreeWidgetItem *m_topitem_multicast;
   QTreeWidgetItem *m_topitem_rest;
   QTreeWidgetItem *m_topitem_rawcan;
-  QTreeWidgetItem *m_topitem_rawmqtt;
  
   
 };

--- a/vscpworks.pro
+++ b/vscpworks.pro
@@ -43,6 +43,7 @@ SOURCES +=  src/main.cpp \
     src/cdlgcanfilter.cpp \
     src/cdlgtls.cpp \
     src/cfrmsession.cpp \
+    src/cfrmmqttexplorer.cpp \
     src/cfrmvscplinktest.cpp \
     src/vscpworks.cpp \
     src/canalconfigwizard.cpp \
@@ -93,7 +94,6 @@ HEADERS  += src/vscpworks.h \
     src/cdlgconnsettingsudp.h \
     src/cdlgconnsettingsmulticast.h \
     src/cdlgconnsettingsrawcan.h \
-    src/cdlgconnsettingsrawmqtt.h \
     src/cdlgconnsettingsrest.h \
     src/cdlglevel1filter.h \
     src/cdlglevel1filterwizard.h \
@@ -101,6 +101,7 @@ HEADERS  += src/vscpworks.h \
     src/cdlgcanfilter.h \
     src/cdlgtls.h \
     src/cfrmsession.h \
+    src/cfrmmqttexplorer.h \
     src/cfrmvscplinktest.h \
     src/canalconfigwizard.h \
     vscp/src/vscp/common/version.h \


### PR DESCRIPTION
## Summary
- add a new CFrmMqttExplorer session window for MQTT connections
- support connect/disconnect, publish, subscribe/unsubscribe (including wildcard topics)
- render subscribed topics and incoming messages in an expandable tree hierarchy
- add message filtering by topic/payload
- detect and present JSON/XML payloads in structured form
- support copying and saving selected message data
- integrate MQTT Explorer entry points in File menu and connection context menu
- include required build wiring in CMake/qmake files

## Notes
- verified the project builds successfully with Qt at ~/Qt/6.11.1/gcc_64