### PR TITLE
Follow-up: raw CAN auto-connect and color-coded frame log

### DIFF
--- a/docs/connection_socketcan.md
+++ b/docs/connection_socketcan.md
@@ -50,6 +50,8 @@ For SocketCAN connections there is also a dedicated frame session window availab
 
 The payload field supports both classic hex input (`11 22 33` or `112233`) and comma-separated byte values where `0x` is hexadecimal, `0o` is octal, `0b`/`ob` is binary and plain values are decimal, for example `0x11,0o10,0b11,4`.
 
+The frame log is color-coded to make traffic easier to read: TX/RX rows use different colors and the frame type/flags cell is highlighted for Remote, FD, BRS and ESI frames.
+
 ## Testing
 
 If you have can utils installed you can use the `cansend` and `candump` utilities to test your the socketcan support of VSCP Works. You can install can-utils with the following commands.

--- a/src/cfrmrawcansession.cpp
+++ b/src/cfrmrawcansession.cpp
@@ -43,7 +43,6 @@
 #include <QMap>
 #include <QMessageBox>
 #include <QSignalBlocker>
-#include <QTimer>
 #include <QUrl>
 #include <QVBoxLayout>
 #include <QtSerialBus/QCanBus>
@@ -53,6 +52,7 @@
 CFrmRawCanSession::CFrmRawCanSession(QWidget* parent, json* pconn)
   : QDialog(parent)
   , m_canDevice(nullptr)
+  , m_autoConnectAttempted(false)
   , m_statusLabel(nullptr)
   , m_comboViewMode(nullptr)
   , m_tableIdFilters(nullptr)
@@ -79,10 +79,8 @@ CFrmRawCanSession::CFrmRawCanSession(QWidget* parent, json* pconn)
   if (m_connObject.contains("device") && m_connObject["device"].is_string()) {
     m_interfaceName = m_connObject["device"].get<std::string>().c_str();
   }
-
   setupUi();
   setConnectedState(false);
-  QTimer::singleShot(0, this, &CFrmRawCanSession::connectOrDisconnect);
 }
 
 CFrmRawCanSession::~CFrmRawCanSession()
@@ -91,6 +89,18 @@ CFrmRawCanSession::~CFrmRawCanSession()
     m_canDevice->disconnectDevice();
     delete m_canDevice;
     m_canDevice = nullptr;
+  }
+}
+
+// ----------------------------------------------------------------------------
+
+void
+CFrmRawCanSession::showEvent(QShowEvent* event)
+{
+  QDialog::showEvent(event);
+  if (!m_autoConnectAttempted && (nullptr == m_canDevice)) {
+    m_autoConnectAttempted = true;
+    connectOrDisconnect();
   }
 }
 
@@ -491,6 +501,7 @@ CFrmRawCanSession::appendFrame(const QCanBusFrame& frame, const QString& directi
 // ----------------------------------------------------------------------------
 
 void
+CFrmRawCanSession::refreshViews()
 {
   if (m_stackViews->currentWidget() == m_tableFrames) {
     refreshFrameView();

--- a/src/cfrmrawcansession.cpp
+++ b/src/cfrmrawcansession.cpp
@@ -531,13 +531,33 @@ CFrmRawCanSession::refreshFrameView()
                                 : (QCanBusFrame::RemoteRequestFrame == rec.frame.frameType()) ? tr("Remote")
                                                                                                 : tr("Other");
 
-    m_tableFrames->setItem(row, 0, new QTableWidgetItem(rec.timestamp.toString(Qt::ISODateWithMs)));
-    m_tableFrames->setItem(row, 1, new QTableWidgetItem(rec.direction));
-    m_tableFrames->setItem(row, 2, new QTableWidgetItem(formatId(rec.frame.frameId(), rec.frame.hasExtendedFrameFormat())));
-    m_tableFrames->setItem(row, 3, new QTableWidgetItem(rec.frame.hasExtendedFrameFormat() ? tr("EXT") : tr("STD")));
-    m_tableFrames->setItem(row, 4, new QTableWidgetItem(frameType + " " + frameFlagsToString(rec.frame)));
-    m_tableFrames->setItem(row, 5, new QTableWidgetItem(QString::number(rec.frame.payload().size())));
-    m_tableFrames->setItem(row, 6, new QTableWidgetItem(formatPayload(rec.frame.payload())));
+    QTableWidgetItem* timeItem = new QTableWidgetItem(rec.timestamp.toString(Qt::ISODateWithMs));
+    QTableWidgetItem* dirItem  = new QTableWidgetItem(rec.direction);
+    QTableWidgetItem* idItem =
+      new QTableWidgetItem(formatId(rec.frame.frameId(), rec.frame.hasExtendedFrameFormat()));
+    QTableWidgetItem* formatItem =
+      new QTableWidgetItem(rec.frame.hasExtendedFrameFormat() ? tr("EXT") : tr("STD"));
+    QTableWidgetItem* typeItem = new QTableWidgetItem(frameType + " " + frameFlagsToString(rec.frame));
+    QTableWidgetItem* dlcItem  = new QTableWidgetItem(QString::number(rec.frame.payload().size()));
+    QTableWidgetItem* dataItem = new QTableWidgetItem(formatPayload(rec.frame.payload()));
+
+    const QColor rowBgColor = rowBackgroundColorForDirection(rec.direction);
+    const QColor rowFgColor = rowForegroundColorForDirection(rec.direction);
+    for (QTableWidgetItem* item : { timeItem, dirItem, idItem, formatItem, typeItem, dlcItem, dataItem }) {
+      item->setBackground(rowBgColor);
+      item->setForeground(rowFgColor);
+    }
+
+    typeItem->setBackground(frameTypeBackgroundColor(rec.frame));
+    typeItem->setForeground(frameTypeForegroundColor(rec.frame));
+
+    m_tableFrames->setItem(row, 0, timeItem);
+    m_tableFrames->setItem(row, 1, dirItem);
+    m_tableFrames->setItem(row, 2, idItem);
+    m_tableFrames->setItem(row, 3, formatItem);
+    m_tableFrames->setItem(row, 4, typeItem);
+    m_tableFrames->setItem(row, 5, dlcItem);
+    m_tableFrames->setItem(row, 6, dataItem);
   }
 
   m_tableFrames->scrollToBottom();
@@ -619,6 +639,78 @@ CFrmRawCanSession::refreshSummaryView()
     m_tableSummary->setItem(row, 3, new QTableWidgetItem(avgGap));
     m_tableSummary->setItem(row, 4, new QTableWidgetItem(formatPayload(data.lastPayload)));
   }
+}
+
+// ----------------------------------------------------------------------------
+
+QColor
+CFrmRawCanSession::rowBackgroundColorForDirection(const QString& direction) const
+{
+  if (direction == tr("TX")) {
+    return QColor(235, 244, 255);
+  }
+  if (direction == tr("RX")) {
+    return QColor(236, 248, 236);
+  }
+
+  return QColor(Qt::white);
+}
+
+// ----------------------------------------------------------------------------
+
+QColor
+CFrmRawCanSession::rowForegroundColorForDirection(const QString& direction) const
+{
+  if (direction == tr("TX")) {
+    return QColor(13, 71, 161);
+  }
+  if (direction == tr("RX")) {
+    return QColor(27, 94, 32);
+  }
+
+  return QColor(Qt::black);
+}
+
+// ----------------------------------------------------------------------------
+
+QColor
+CFrmRawCanSession::frameTypeBackgroundColor(const QCanBusFrame& frame) const
+{
+  if (QCanBusFrame::RemoteRequestFrame == frame.frameType()) {
+    return QColor(243, 229, 245);
+  }
+  if (frame.hasErrorStateIndicator()) {
+    return QColor(255, 235, 238);
+  }
+  if (frame.hasBitrateSwitch()) {
+    return QColor(224, 247, 250);
+  }
+  if (frame.hasFlexibleDataRateFormat()) {
+    return QColor(227, 242, 253);
+  }
+
+  return QColor(250, 250, 250);
+}
+
+// ----------------------------------------------------------------------------
+
+QColor
+CFrmRawCanSession::frameTypeForegroundColor(const QCanBusFrame& frame) const
+{
+  if (QCanBusFrame::RemoteRequestFrame == frame.frameType()) {
+    return QColor(74, 20, 140);
+  }
+  if (frame.hasErrorStateIndicator()) {
+    return QColor(183, 28, 28);
+  }
+  if (frame.hasBitrateSwitch()) {
+    return QColor(0, 96, 100);
+  }
+  if (frame.hasFlexibleDataRateFormat()) {
+    return QColor(13, 71, 161);
+  }
+
+  return QColor(33, 33, 33);
 }
 
 // ----------------------------------------------------------------------------

--- a/src/cfrmrawcansession.h
+++ b/src/cfrmrawcansession.h
@@ -41,6 +41,7 @@
 #include <QLabel>
 #include <QLineEdit>
 #include <QPushButton>
+#include <QShowEvent>
 #include <QStackedWidget>
 #include <QTableWidget>
 #include <QVector>
@@ -67,6 +68,9 @@ private slots:
   void addIdFilter();
   void removeSelectedIdFilter();
   void onFilterTableChanged(QTableWidgetItem* item);
+
+protected:
+  void showEvent(QShowEvent* event) override;
 
 private:
   struct FrameRecord {
@@ -102,6 +106,7 @@ private:
   QCanBusDevice* m_canDevice;
   QVector<FrameRecord> m_frameHistory;
   QVector<IdFilterRange> m_idFilters;
+  bool m_autoConnectAttempted;
 
   QLabel* m_statusLabel;
   QComboBox* m_comboViewMode;

--- a/src/cfrmrawcansession.h
+++ b/src/cfrmrawcansession.h
@@ -35,6 +35,7 @@
 #include <QtSerialBus/QCanBusFrame>
 
 #include <QCheckBox>
+#include <QColor>
 #include <QComboBox>
 #include <QDateTime>
 #include <QDialog>
@@ -96,6 +97,10 @@ private:
   void refreshFrameView();
   void refreshSummaryView();
   void refreshFilterModelFromTable();
+  QColor rowBackgroundColorForDirection(const QString& direction) const;
+  QColor rowForegroundColorForDirection(const QString& direction) const;
+  QColor frameTypeBackgroundColor(const QCanBusFrame& frame) const;
+  QColor frameTypeForegroundColor(const QCanBusFrame& frame) const;
   QString formatId(uint32_t id, bool extended) const;
   QString formatPayload(const QByteArray& payload) const;
   QString frameFlagsToString(const QCanBusFrame& frame) const;


### PR DESCRIPTION
## Summary
- make raw CAN session connect automatically when the window opens
- add color coding for TX/RX rows in frame log
- add frame type/flags highlighting for Remote, FD, BRS and ESI
- include earlier payload parsing and view/filter follow-ups on this branch
