### PR TITLE
Add colorful log viewer dialog under Help menu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,6 +251,10 @@ qt_add_executable(${PROJECT_NAME}
   src/canalconfigwizard.h
   src/canalconfigwizard.cpp
 
+  src/cdlglogviewer.ui
+  src/cdlglogviewer.h
+  src/cdlglogviewer.cpp
+
   src/eventlistmodel.h
   src/eventlistmodel.cpp
 

--- a/src/cdlglogviewer.cpp
+++ b/src/cdlglogviewer.cpp
@@ -1,0 +1,403 @@
+// cdlglogviewer.cpp
+//
+// This file is part of the VSCP (https://www.vscp.org)
+//
+// The MIT License (MIT)
+//
+// Copyright (C) 2000-2026 Ake Hedman, Grodans Paradis AB
+// <info@grodansparadis.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+#include "cdlglogviewer.h"
+#include "ui_cdlglogviewer.h"
+#include "vscpworks.h"
+
+#include <QFile>
+#include <QTextStream>
+#include <QFileDialog>
+#include <QTableWidgetItem>
+#include <QHeaderView>
+#include <QFont>
+#include <QScrollBar>
+#include <QRegularExpression>
+#include <QApplication>
+
+///////////////////////////////////////////////////////////////////////////////
+// CDlgLogViewer
+//
+
+CDlgLogViewer::CDlgLogViewer(QWidget *parent)
+    : QDialog(parent)
+    , ui(new Ui::CDlgLogViewer)
+    , m_autoRefreshTimer(new QTimer(this))
+{
+    ui->setupUi(this);
+
+    setWindowFlags(windowFlags() | Qt::WindowMaximizeButtonHint);
+
+    // Table setup
+    ui->tableLog->setColumnCount(2);
+    ui->tableLog->horizontalHeader()->setStretchLastSection(true);
+    ui->tableLog->horizontalHeader()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
+    ui->tableLog->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
+    ui->tableLog->verticalHeader()->setVisible(false);
+    ui->tableLog->setShowGrid(false);
+
+    QFont monoFont("Monospace");
+    monoFont.setStyleHint(QFont::TypeWriter);
+    monoFont.setPointSize(9);
+    ui->tableLog->setFont(monoFont);
+
+    // Dark background for the table
+    ui->tableLog->setStyleSheet(
+        "QTableWidget {"
+        "  background-color: #1e1e1e;"
+        "  gridline-color: #2d2d2d;"
+        "  color: #d4d4d4;"
+        "}"
+        "QTableWidget::item:selected {"
+        "  background-color: #264f78;"
+        "  color: #ffffff;"
+        "}"
+        "QHeaderView::section {"
+        "  background-color: #252526;"
+        "  color: #cccccc;"
+        "  border: 1px solid #3e3e42;"
+        "  padding: 4px;"
+        "  font-weight: bold;"
+        "}"
+    );
+
+    // Auto-refresh timer
+    m_autoRefreshTimer->setInterval(5000);
+    connect(m_autoRefreshTimer, &QTimer::timeout, this, &CDlgLogViewer::onAutoRefreshTick);
+
+    // Connections
+    connect(ui->btnRefresh,      &QPushButton::clicked,          this, &CDlgLogViewer::onRefresh);
+    connect(ui->btnClear,        &QPushButton::clicked,          this, &CDlgLogViewer::onClearDisplay);
+    connect(ui->btnSave,         &QPushButton::clicked,          this, &CDlgLogViewer::onSave);
+    connect(ui->chkAutoRefresh,  &QCheckBox::toggled,            this, &CDlgLogViewer::onAutoRefreshToggled);
+    connect(ui->comboLevel,      QOverload<int>::of(&QComboBox::currentIndexChanged),
+                                                                  this, &CDlgLogViewer::onFilterChanged);
+    connect(ui->editSearch,      &QLineEdit::textChanged,        this, &CDlgLogViewer::onSearchChanged);
+
+    loadLogFile();
+}
+
+CDlgLogViewer::~CDlgLogViewer()
+{
+    delete ui;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// levelColor  – foreground text colour for a given level string
+//
+
+QColor
+CDlgLogViewer::levelColor(const QString &level) const
+{
+    QString l = level.toLower();
+    if (l == "trace")    return QColor(0x88, 0x88, 0x88);   // dim grey
+    if (l == "debug")    return QColor(0x56, 0xd3, 0xef);   // cyan
+    if (l == "info")     return QColor(0x6a, 0xd9, 0x6f);   // green
+    if (l == "warn" || l == "warning")
+                         return QColor(0xff, 0xd7, 0x00);   // golden yellow
+    if (l == "err" || l == "error")
+                         return QColor(0xff, 0x55, 0x55);   // red
+    if (l == "critical") return QColor(0xff, 0x00, 0x7f);   // hot pink
+    return QColor(0xd4, 0xd4, 0xd4);                        // default white
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// levelBackgroundColor  – subtle tinted row background
+//
+
+QColor
+CDlgLogViewer::levelBackgroundColor(const QString &level) const
+{
+    QString l = level.toLower();
+    if (l == "trace")    return QColor(0x22, 0x22, 0x22);
+    if (l == "debug")    return QColor(0x1a, 0x26, 0x2e);
+    if (l == "info")     return QColor(0x1a, 0x26, 0x1a);
+    if (l == "warn" || l == "warning")
+                         return QColor(0x2e, 0x28, 0x10);
+    if (l == "err" || l == "error")
+                         return QColor(0x30, 0x14, 0x14);
+    if (l == "critical") return QColor(0x38, 0x08, 0x1a);
+    return QColor(0x1e, 0x1e, 0x1e);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// parseLevelEnum
+//
+
+CDlgLogViewer::LogLevel
+CDlgLogViewer::parseLevelEnum(const QString &level) const
+{
+    QString l = level.toLower();
+    if (l == "trace")    return LogLevel::TRACE;
+    if (l == "debug")    return LogLevel::DEBUG;
+    if (l == "info")     return LogLevel::INFO;
+    if (l == "warn" || l == "warning")  return LogLevel::WARNING;
+    if (l == "err" || l == "error")     return LogLevel::ERR;
+    if (l == "critical") return LogLevel::CRITICAL;
+    return LogLevel::ALL;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// loadLogFile  – reads the spdlog rotating file and parses entries
+//
+
+void
+CDlgLogViewer::loadLogFile()
+{
+    vscpworks *pworks = (vscpworks *)QCoreApplication::instance();
+
+    QString path = QString::fromStdString(pworks->m_fileLogPath);
+
+    m_entries.clear();
+
+    QFile file(path);
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        // If file not found, show a placeholder entry
+        LogEntry e;
+        e.level   = "info";
+        e.message = QString("Log file not found: %1").arg(path);
+        m_entries.append(e);
+        applyFilter();
+        return;
+    }
+
+    // spdlog pattern: "[%^%l%$] %v"
+    // The colour markers %^ / %$ are stripped in file sinks, so
+    // lines look like:  [info] some message text
+    // They may also contain ANSI escape sequences if the pattern uses
+    // a colour sink accidentally – strip those too.
+    static const QRegularExpression ansiEscape("\x1B\\[[0-9;]*m");
+    // Match   [level] message   with optional leading ANSI colour codes
+    static const QRegularExpression lineRe(R"(^\[([a-zA-Z]+)\]\s+(.*)$)");
+
+    QTextStream in(&file);
+    while (!in.atEnd()) {
+        QString line = in.readLine();
+        // Strip ANSI escapes
+        line.remove(ansiEscape);
+        line = line.trimmed();
+        if (line.isEmpty()) continue;
+
+        auto match = lineRe.match(line);
+        if (match.hasMatch()) {
+            LogEntry e;
+            e.level   = match.captured(1);
+            e.message = match.captured(2);
+            m_entries.append(e);
+        }
+        else {
+            // Continuation / unparsed line – append as info entry
+            LogEntry e;
+            e.level   = "info";
+            e.message = line;
+            m_entries.append(e);
+        }
+    }
+
+    file.close();
+    applyFilter();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// applyFilter  – populates the table based on current level + search criteria
+//
+
+void
+CDlgLogViewer::applyFilter()
+{
+    QString search      = ui->editSearch->text().trimmed();
+    int     levelIndex  = ui->comboLevel->currentIndex();
+    LogLevel filterLevel = static_cast<LogLevel>(levelIndex);
+
+    // Minimum numeric severity for >= filtering
+    auto levelSeverity = [](LogLevel l) -> int {
+        switch (l) {
+            case LogLevel::TRACE:    return 0;
+            case LogLevel::DEBUG:    return 1;
+            case LogLevel::INFO:     return 2;
+            case LogLevel::WARNING:  return 3;
+            case LogLevel::ERR:      return 4;
+            case LogLevel::CRITICAL: return 5;
+            default:                 return -1;
+        }
+    };
+    int minSeverity = levelSeverity(filterLevel);
+
+    ui->tableLog->setUpdatesEnabled(false);
+    ui->tableLog->clearContents();
+    ui->tableLog->setRowCount(0);
+
+    int visibleCount = 0;
+    for (const LogEntry &e : qAsConst(m_entries)) {
+        // Severity filter
+        if (filterLevel != LogLevel::ALL) {
+            int sev = levelSeverity(parseLevelEnum(e.level));
+            if (sev < minSeverity) continue;
+        }
+        // Text search
+        if (!search.isEmpty() &&
+            !e.message.contains(search, Qt::CaseInsensitive) &&
+            !e.level.contains(search, Qt::CaseInsensitive)) {
+            continue;
+        }
+
+        int row = ui->tableLog->rowCount();
+        ui->tableLog->insertRow(row);
+
+        QColor fg = levelColor(e.level);
+        QColor bg = levelBackgroundColor(e.level);
+
+        // Level column
+        auto *levelItem = new QTableWidgetItem(e.level.toUpper());
+        levelItem->setForeground(fg);
+        levelItem->setBackground(bg);
+        QFont boldFont = ui->tableLog->font();
+        boldFont.setBold(true);
+        levelItem->setFont(boldFont);
+        levelItem->setTextAlignment(Qt::AlignCenter | Qt::AlignVCenter);
+        ui->tableLog->setItem(row, 0, levelItem);
+
+        // Message column
+        auto *msgItem = new QTableWidgetItem(e.message);
+        msgItem->setForeground(fg);
+        msgItem->setBackground(bg);
+        ui->tableLog->setItem(row, 1, msgItem);
+
+        ++visibleCount;
+    }
+
+    ui->tableLog->setUpdatesEnabled(true);
+
+    // Scroll to last entry
+    if (ui->tableLog->rowCount() > 0) {
+        ui->tableLog->scrollToBottom();
+    }
+
+    ui->labelEntries->setText(
+        QString("Entries: %1 / %2").arg(visibleCount).arg(m_entries.size()));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// onRefresh
+//
+
+void
+CDlgLogViewer::onRefresh()
+{
+    loadLogFile();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// onClearDisplay
+//
+
+void
+CDlgLogViewer::onClearDisplay()
+{
+    m_entries.clear();
+    ui->tableLog->clearContents();
+    ui->tableLog->setRowCount(0);
+    ui->labelEntries->setText("Entries: 0 / 0");
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// onSave  – save visible rows to a text file
+//
+
+void
+CDlgLogViewer::onSave()
+{
+    QString fileName = QFileDialog::getSaveFileName(
+        this,
+        tr("Save Log"),
+        QString(),
+        tr("Text files (*.txt);;All files (*)"));
+
+    if (fileName.isEmpty()) return;
+
+    QFile file(fileName);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        return;
+    }
+
+    QTextStream out(&file);
+    for (int row = 0; row < ui->tableLog->rowCount(); ++row) {
+        QString level = ui->tableLog->item(row, 0)
+                            ? ui->tableLog->item(row, 0)->text()
+                            : QString();
+        QString msg   = ui->tableLog->item(row, 1)
+                            ? ui->tableLog->item(row, 1)->text()
+                            : QString();
+        out << QString("[%1] %2\n").arg(level, -8).arg(msg);
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// onAutoRefreshToggled
+//
+
+void
+CDlgLogViewer::onAutoRefreshToggled(bool checked)
+{
+    if (checked) {
+        m_autoRefreshTimer->start();
+    }
+    else {
+        m_autoRefreshTimer->stop();
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// onAutoRefreshTick
+//
+
+void
+CDlgLogViewer::onAutoRefreshTick()
+{
+    loadLogFile();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// onFilterChanged
+//
+
+void
+CDlgLogViewer::onFilterChanged()
+{
+    applyFilter();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// onSearchChanged
+//
+
+void
+CDlgLogViewer::onSearchChanged(const QString &)
+{
+    applyFilter();
+}

--- a/src/cdlglogviewer.h
+++ b/src/cdlglogviewer.h
@@ -1,0 +1,79 @@
+// cdlglogviewer.h
+//
+// This file is part of the VSCP (https://www.vscp.org)
+//
+// The MIT License (MIT)
+//
+// Copyright (C) 2000-2026 Ake Hedman, Grodans Paradis AB
+// <info@grodansparadis.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+#ifndef CDLGLOGVIEWER_H
+#define CDLGLOGVIEWER_H
+
+#include <QDialog>
+#include <QTimer>
+#include <QColor>
+
+namespace Ui {
+class CDlgLogViewer;
+}
+
+class CDlgLogViewer : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit CDlgLogViewer(QWidget *parent = nullptr);
+    ~CDlgLogViewer();
+
+    enum class LogLevel { ALL, TRACE, DEBUG, INFO, WARNING, ERR, CRITICAL };
+
+private slots:
+    void onRefresh();
+    void onClearDisplay();
+    void onSave();
+    void onAutoRefreshToggled(bool checked);
+    void onFilterChanged();
+    void onSearchChanged(const QString &text);
+    void onAutoRefreshTick();
+
+private:
+    void loadLogFile();
+    void applyFilter();
+    void addLogRow(const QString &levelStr, const QString &message, int rawRow);
+
+    QColor levelColor(const QString &level) const;
+    QColor levelBackgroundColor(const QString &level) const;
+    LogLevel parseLevelEnum(const QString &level) const;
+
+    Ui::CDlgLogViewer *ui;
+    QTimer *m_autoRefreshTimer;
+
+    // Raw parsed log entries
+    struct LogEntry {
+        QString level;
+        QString message;
+    };
+    QList<LogEntry> m_entries;
+};
+
+#endif // CDLGLOGVIEWER_H

--- a/src/cdlglogviewer.ui
+++ b/src/cdlglogviewer.ui
@@ -1,0 +1,230 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>CDlgLogViewer</class>
+ <widget class="QDialog" name="CDlgLogViewer">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>1000</width>
+    <height>650</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Application Log Viewer</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1,0">
+   <property name="spacing">
+    <number>6</number>
+   </property>
+   <property name="contentsMargins">
+    <number>8</number>
+    <number>8</number>
+    <number>8</number>
+    <number>8</number>
+   </property>
+
+   <!-- Top filter bar -->
+   <item>
+    <layout class="QHBoxLayout" name="filterLayout">
+     <item>
+      <widget class="QLabel" name="labelLevel">
+       <property name="text">
+        <string>Level:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="comboLevel">
+       <item>
+        <property name="text">
+         <string>All</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Trace</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Debug</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Info</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Warning</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Error</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Critical</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="labelSearch">
+       <property name="text">
+        <string>Search:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="editSearch">
+       <property name="placeholderText">
+        <string>Filter log messages...</string>
+       </property>
+       <property name="clearButtonEnabled">
+        <bool>true</bool>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>1</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnRefresh">
+       <property name="text">
+        <string>⟳ Refresh</string>
+       </property>
+       <property name="toolTip">
+        <string>Reload the log file</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+
+   <!-- Log table -->
+   <item>
+    <widget class="QTableWidget" name="tableLog">
+     <property name="alternatingRowColors">
+      <bool>false</bool>
+     </property>
+     <property name="selectionBehavior">
+      <enum>QAbstractItemView::SelectRows</enum>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::ExtendedSelection</enum>
+     </property>
+     <property name="showGrid">
+      <bool>true</bool>
+     </property>
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+     <column>
+      <property name="text">
+       <string>Level</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Message</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+
+   <!-- Bottom button bar -->
+   <item>
+    <layout class="QHBoxLayout" name="bottomLayout">
+     <item>
+      <widget class="QCheckBox" name="chkAutoRefresh">
+       <property name="text">
+        <string>Auto-refresh (5s)</string>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="labelEntries">
+       <property name="text">
+        <string>Entries: 0</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnClear">
+       <property name="text">
+        <string>Clear Display</string>
+       </property>
+       <property name="toolTip">
+        <string>Clear the displayed log (does not delete the log file)</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnSave">
+       <property name="text">
+        <string>Save...</string>
+       </property>
+       <property name="toolTip">
+        <string>Save visible entries to a text file</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnClose">
+       <property name="text">
+        <string>Close</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>btnClose</sender>
+   <signal>clicked()</signal>
+   <receiver>CDlgLogViewer</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>899</x>
+     <y>620</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>500</x>
+     <y>325</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -62,6 +62,7 @@
 #include "cdlgconnsettingsws1.h"
 #include "cdlgconnsettingsws2.h"
 #include "cdlgknownguid.h"
+#include "cdlglogviewer.h"
 #include "cdlgmainsettings.h"
 #include "cdlgnewconnection.h"
 #include "cdlgsessionfilter.h"
@@ -1666,6 +1667,12 @@ MainWindow::createActions()
 
   helpMenu->addSeparator();
 
+  QAction* logViewerAct =
+    helpMenu->addAction(tr("View &Log..."), this, &MainWindow::showLogViewer);
+  logViewerAct->setStatusTip(tr("View application log"));
+
+  helpMenu->addSeparator();
+
   QAction* aboutAct =
     helpMenu->addAction(tr("&About"), this, &MainWindow::about);
   aboutAct->setStatusTip(tr("Show the application's About box"));
@@ -3000,3 +3007,14 @@ MainWindow::showHelp(void)
 }
 
 #endif
+
+///////////////////////////////////////////////////////////////////////////////
+// showLogViewer
+//
+
+void
+MainWindow::showLogViewer(void)
+{
+  CDlgLogViewer dlg(this);
+  dlg.exec();
+}

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -184,6 +184,11 @@ private slots:
     */
     void showHelp(void);
 
+    /*!
+        Show the application log viewer
+    */
+    void showLogViewer(void);
+
 protected:        
 
     /*

--- a/vscpworks.pro
+++ b/vscpworks.pro
@@ -47,6 +47,7 @@ SOURCES +=  src/main.cpp \
     src/cfrmrawcansession.cpp \
     src/cfrmvscplinktest.cpp \
     src/vscpworks.cpp \
+    src/cdlglogviewer.cpp \
     src/canalconfigwizard.cpp \
     vscp/src/vscp/common/vscpremotetcpif.cpp \
     vscp/src/vscp/common/vscpdatetime.cpp \
@@ -106,6 +107,7 @@ HEADERS  += src/vscpworks.h \
     src/cfrmrawcansession.h \
     src/cfrmvscplinktest.h \
     src/canalconfigwizard.h \
+    src/cdlglogviewer.h \
     vscp/src/vscp/common/version.h \
     vscp/src/vscp/common/vscp.h \
     vscp/src/vscp/common/vscpremotetcpif.h \
@@ -163,7 +165,8 @@ FORMS += src/mainwindow.ui \
     src/cdlgcanfilter.ui \
     src/cdlgsocketcanflags.ui \
     src/cdlgtls.ui \
-    src/cdlgmqttpublish.ui
+    src/cdlgmqttpublish.ui \
+    src/cdlglogviewer.ui
 
 INCLUDEPATH += ./src \
     ./build \


### PR DESCRIPTION
## Summary

Adds a **Log Viewer** dialog accessible from **Help → View Log...** that lets users inspect the application's spdlog rotating log file directly inside the app.

## Features

- **Level filter** — combo box to show All / Trace / Debug / Info / Warning / Error / Critical entries
- **Live search** — filters rows in real-time as you type
- **Colorful rows** — dark-themed table with per-level highlight colours:
  - 🩶 Trace — dim grey
  - 🩵 Debug — cyan
  - 💚 Info — green
  - 💛 Warning — golden yellow
  - 🔴 Error — red
  - 🩷 Critical — hot pink
- **Auto-refresh** — optional 5-second timer to reload the log file automatically
- **Save** — export currently visible entries to a `.txt` file
- **Entry counter** — shows `visible / total` count in the status bar of the dialog

## Files changed

| File | Change |
|---|---|
| `src/cdlglogviewer.h` | New — dialog class |
| `src/cdlglogviewer.cpp` | New — implementation |
| `src/cdlglogviewer.ui` | New — Qt Designer UI |
| `src/mainwindow.h` | Added `showLogViewer()` slot |
| `src/mainwindow.cpp` | Include, menu item, slot implementation |
| `vscpworks.pro` | Registered new source/header/form |
| `CMakeLists.txt` | Registered new source/header/form |