### PR TITLE
Use dialog timeout values for TCP/IP test connection

### DIFF
--- a/src/cdlgconnsettingstcpip.cpp
+++ b/src/cdlgconnsettingstcpip.cpp
@@ -220,7 +220,9 @@ CDlgConnSettingsTcpip::setInterface(const QString& str)
 uint32_t
 CDlgConnSettingsTcpip::getConnectionTimeout(void)
 {
-  return m_client.getConnectionTimeout();
+  uint32_t timeout = vscp_readStringValue(ui->editConnectTimeout->text().toStdString());
+  m_client.setConnectionTimeout(timeout);
+  return timeout;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -230,6 +232,9 @@ CDlgConnSettingsTcpip::getConnectionTimeout(void)
 void
 CDlgConnSettingsTcpip::setConnectionTimeout(uint32_t timeout)
 {
+  vscpworks* pworks = (vscpworks*)QCoreApplication::instance();
+  QString str       = pworks->decimalToStringInBase(timeout, 10);
+  ui->editConnectTimeout->setText(str);
   m_client.setConnectionTimeout(timeout);
 }
 
@@ -240,7 +245,9 @@ CDlgConnSettingsTcpip::setConnectionTimeout(uint32_t timeout)
 uint32_t
 CDlgConnSettingsTcpip::getResponseTimeout(void)
 {
-  return m_client.getResponseTimeout();
+  uint32_t timeout = vscp_readStringValue(ui->editResponseTimeout->text().toStdString());
+  m_client.setResponseTimeout(timeout);
+  return timeout;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -250,6 +257,9 @@ CDlgConnSettingsTcpip::getResponseTimeout(void)
 void
 CDlgConnSettingsTcpip::setResponseTimeout(uint32_t timeout)
 {
+  vscpworks* pworks = (vscpworks*)QCoreApplication::instance();
+  QString str       = pworks->decimalToStringInBase(timeout, 10);
+  ui->editResponseTimeout->setText(str);
   m_client.setResponseTimeout(timeout);
 }
 
@@ -648,6 +658,9 @@ CDlgConnSettingsTcpip::onTestConnection(void)
   QApplication::setOverrideCursor(Qt::WaitCursor);
   QApplication::processEvents();
 
+  getConnectionTimeout();
+  getResponseTimeout();
+
   // Initialize host connection
   if (VSCP_ERROR_SUCCESS != m_client.init(getHost().toStdString().c_str(),
                                           getUser().toStdString().c_str(),
@@ -712,6 +725,9 @@ CDlgConnSettingsTcpip::onGetInterfaces(void)
   QApplication::setOverrideCursor(Qt::WaitCursor);
   QApplication::processEvents();
 
+  getConnectionTimeout();
+  getResponseTimeout();
+
   // Initialize host connection
   if (VSCP_ERROR_SUCCESS != m_client.init(getHost().toStdString().c_str(),
                                           getUser().toStdString().c_str(),
@@ -720,8 +736,6 @@ CDlgConnSettingsTcpip::onGetInterfaces(void)
     QMessageBox::information(this, tr(APPNAME), tr("Failed to initialize tcp/ip object"));
     return;
   }
-
-  m_client.setResponseTimeout(2000);
 
   // Connect to remote host
   if (VSCP_ERROR_SUCCESS != m_client.connect()) {

--- a/src/cdlgconnsettingstcpip.cpp
+++ b/src/cdlgconnsettingstcpip.cpp
@@ -232,9 +232,7 @@ CDlgConnSettingsTcpip::getConnectionTimeout(void)
 void
 CDlgConnSettingsTcpip::setConnectionTimeout(uint32_t timeout)
 {
-  vscpworks* pworks = (vscpworks*)QCoreApplication::instance();
-  QString str       = pworks->decimalToStringInBase(timeout, 10);
-  ui->editConnectTimeout->setText(str);
+  ui->editConnectTimeout->setText(QString::number(timeout, 10));
   m_client.setConnectionTimeout(timeout);
 }
 

--- a/src/cdlgconnsettingstcpip.cpp
+++ b/src/cdlgconnsettingstcpip.cpp
@@ -255,9 +255,7 @@ CDlgConnSettingsTcpip::getResponseTimeout(void)
 void
 CDlgConnSettingsTcpip::setResponseTimeout(uint32_t timeout)
 {
-  vscpworks* pworks = (vscpworks*)QCoreApplication::instance();
-  QString str       = pworks->decimalToStringInBase(timeout, 10);
-  ui->editResponseTimeout->setText(str);
+  ui->editResponseTimeout->setText(QString::number(timeout, 10));
   m_client.setResponseTimeout(timeout);
 }
 


### PR DESCRIPTION
## Summary\n- make the TCP/IP connection dialog read connect/response timeout values from the edit fields\n- apply those values to the TCP/IP client before running Test connection and Get interfaces\n- remove the hardcoded 2000 ms response timeout override when fetching interfaces\n\n## Why\nThe session edit dialog should honor the timeout values configured in the dialog when testing TCP/IP connections.