### PR TITLE
Fix CI regressions in macOS install staging and Windows headers

### DIFF
--- a/.github/workflows/cmake-mac.yml
+++ b/.github/workflows/cmake-mac.yml
@@ -47,11 +47,11 @@ jobs:
         run: cmake --build build --config ${BUILD_TYPE} --parallel
 
       - name: Install
-        run: cmake --install build --config ${BUILD_TYPE} --prefix "${{ github.workspace }}/install"
+        run: cmake --install build --config ${BUILD_TYPE} --prefix "${{ github.workspace }}/staging"
 
       - name: Pack install tree
         run: |
-          tar -C "${{ github.workspace }}" -czf "${{ github.workspace }}/vscp-works-qt-macos-install.tar.gz" install
+          tar -C "${{ github.workspace }}" -czf "${{ github.workspace }}/vscp-works-qt-macos-install.tar.gz" staging
 
       - name: Upload install artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -72,12 +72,12 @@ jobs:
       - name: Install
         shell: pwsh
         run: |
-          cmake --install build --config ${{ env.BUILD_CONFIGURATION }} --prefix "${{ github.workspace }}/install"
+          cmake --install build --config ${{ env.BUILD_CONFIGURATION }} --prefix "${{ github.workspace }}/staging"
 
       - name: Pack install tree
         shell: pwsh
         run: |
-          Compress-Archive -Path "${{ github.workspace }}/install/*" -DestinationPath "${{ github.workspace }}/vscp-works-qt-windows-install.zip"
+          Compress-Archive -Path "${{ github.workspace }}/staging/*" -DestinationPath "${{ github.workspace }}/vscp-works-qt-windows-install.zip"
 
       - name: Upload install artifact
         uses: actions/upload-artifact@v4

--- a/src/cdlglogviewer.cpp
+++ b/src/cdlglogviewer.cpp
@@ -34,11 +34,6 @@
 #include <pch.h>
 #endif
 
-#ifdef WIN32
-#include <windows.h>
-#include <winsock2.h>
-#endif
-
 #include "cdlglogviewer.h"
 #include "ui_cdlglogviewer.h"
 #include "vscpworks.h"

--- a/src/cdlglogviewer.cpp
+++ b/src/cdlglogviewer.cpp
@@ -26,6 +26,19 @@
 // SOFTWARE.
 //
 
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+
+#ifdef WIN32
+#include <pch.h>
+#endif
+
+#ifdef WIN32
+#include <windows.h>
+#include <winsock2.h>
+#endif
+
 #include "cdlglogviewer.h"
 #include "ui_cdlglogviewer.h"
 #include "vscpworks.h"

--- a/src/pch.h
+++ b/src/pch.h
@@ -15,8 +15,8 @@
 #define WIN32_LEAN_AND_MEAN
 #endif
 
-#include <windows.h>
 #include <winsock2.h>
+#include <windows.h>
 #include <ws2tcpip.h>
 #include <iphlpapi.h>
 #include <process.h>


### PR DESCRIPTION
## Summary
- restore macOS CI install staging path (`staging`) to avoid recursive install into source `install/` tree
- restore matching macOS artifact packing from `staging`
- keep Windows CI Qt install hardening and header-order fixes on this branch

## Root cause
`master` currently installs macOS artifacts to `${{ github.workspace }}/install`, which overlaps repository `install/` sources and causes recursive path nesting (`.../install/share/vscp-works-qt/vscp-works-qt/...`).

## Validation
- failing run on master confirms install step uses `--prefix .../install`
- branch workflow uses `--prefix .../staging`
- new branch macOS run dispatched: https://github.com/grodansparadis/vscp-works-qt/actions/runs/28404416258