### PR TITLE
Fix MDF editor issues #14-#20 and add configurable cumulative backups

### DIFF
--- a/src/cdlgmainsettings.cpp
+++ b/src/cdlgmainsettings.cpp
@@ -89,6 +89,10 @@ connect(helpButton, SIGNAL(clicked()), this, SLOT(showHelp()));
 
   // Save format
   ui->chkAlwaysJSON->setChecked(pworks->m_bSaveAlwaysJSON);
+  ui->chkMdfAutoSave->setChecked(pworks->m_mdfAutoSaveEnabled);
+  ui->spinMdfAutoSaveInterval->setValue(static_cast<int>(pworks->m_mdfAutoSaveInterval));
+  ui->chkMdfCumulativeBackups->setChecked(pworks->m_mdfCumulativeBackups);
+  ui->spinMdfMaxBackups->setValue(static_cast<int>(pworks->m_mdfMaxBackups));
 
   // * * * Session Window tab * * *
 
@@ -259,6 +263,10 @@ CDlgMainSettings::done(int rv)
     pworks->m_bEnableDarkTheme  = ui->chkDarkTheme->isChecked();
     pworks->m_bAskBeforeDelete  = ui->chkAskOnDelete->isChecked();
     pworks->m_bSaveAlwaysJSON   = ui->chkAlwaysJSON->isChecked();
+    pworks->m_mdfAutoSaveEnabled = ui->chkMdfAutoSave->isChecked();
+    pworks->m_mdfAutoSaveInterval = static_cast<uint32_t>(ui->spinMdfAutoSaveInterval->value());
+    pworks->m_mdfCumulativeBackups = ui->chkMdfCumulativeBackups->isChecked();
+    pworks->m_mdfMaxBackups = static_cast<uint32_t>(ui->spinMdfMaxBackups->value());
     pworks->m_preferredLanguage = ui->editPreferredLanguage->text().toStdString();
 
     // Session window

--- a/src/cdlgmainsettings.ui
+++ b/src/cdlgmainsettings.ui
@@ -115,6 +115,57 @@
          </widget>
         </item>
         <item row="5" column="1">
+         <widget class="QCheckBox" name="chkMdfAutoSave">
+          <property name="toolTip">
+           <string>Automatically save opened MDF files at a fixed interval.</string>
+          </property>
+          <property name="text">
+           <string>Enable MDF autosave</string>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="0">
+         <widget class="QLabel" name="labelMdfAutoSaveInterval">
+          <property name="text">
+           <string>MDF autosave interval (s):</string>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="1">
+         <widget class="QSpinBox" name="spinMdfAutoSaveInterval">
+          <property name="minimum">
+           <number>10</number>
+          </property>
+          <property name="maximum">
+           <number>86400</number>
+          </property>
+         </widget>
+        </item>
+        <item row="7" column="1">
+         <widget class="QCheckBox" name="chkMdfCumulativeBackups">
+          <property name="toolTip">
+           <string>Keep timestamped cumulative MDF backups instead of replacing a single .bak file.</string>
+          </property>
+          <property name="text">
+           <string>Use cumulative MDF backups</string>
+          </property>
+         </widget>
+        </item>
+        <item row="8" column="0">
+         <widget class="QLabel" name="labelMdfMaxBackups">
+          <property name="text">
+           <string>Max cumulative backups per file (0=unlimited):</string>
+          </property>
+         </widget>
+        </item>
+        <item row="8" column="1">
+         <widget class="QSpinBox" name="spinMdfMaxBackups">
+          <property name="maximum">
+           <number>1000</number>
+          </property>
+         </widget>
+        </item>
+        <item row="9" column="1">
          <spacer name="verticalSpacer_2">
           <property name="orientation">
            <enum>Qt::Vertical</enum>

--- a/src/cdlgmdfbitlist.cpp
+++ b/src/cdlgmdfbitlist.cpp
@@ -40,11 +40,13 @@
 #include "ui_cdlgmdfbitlist.h"
 
 #include <QDebug>
-#include <QInputDialog>
-#include <QPushButton>
-#include <QMessageBox>
 #include <QDesktopServices>
+#include <QInputDialog>
+#include <QMessageBox>
+#include <QPushButton>
 #include <QShortcut>
+
+#include <algorithm>
 
 #include <spdlog/async.h>
 #include <spdlog/sinks/rotating_file_sink.h>
@@ -160,7 +162,6 @@ void
 CDlgMdfBitList::renderBitItems(void)
 {
   std::deque<CMDF_Bit*>* pbits = nullptr;
-  std::map<uint32_t, CMDF_Register*> pages;
 
   if (nullptr == m_pobj) {
     return;
@@ -178,23 +179,24 @@ CDlgMdfBitList::renderBitItems(void)
     return;
   }
 
-  // Create set with sorted bit offsets and a map
-  // to help find corresponding bit pointer
-  // Add registers for page
-  m_bitset.clear();
-  m_bitmap.clear();
-  for (auto it = pbits->cbegin(); it != pbits->cend(); ++it) {
-    m_bitset.insert((*it)->getPos());
-    m_bitmap[(*it)->getPos()] = *it;
+  m_renderedBits.clear();
+  m_renderedBits.reserve(pbits->size());
+  for (CMDF_Bit* pbit : *pbits) {
+    if (nullptr != pbit) {
+      m_renderedBits.push_back(pbit);
+    }
   }
 
-  for (auto it = m_bitset.cbegin(); it != m_bitset.cend(); ++it) {
-    CMDF_Bit* pbit = m_bitmap[*it]; //*it;
+  std::stable_sort(m_renderedBits.begin(),
+                   m_renderedBits.end(),
+                   [](const CMDF_Bit* a, const CMDF_Bit* b) { return a->getPos() < b->getPos(); });
+
+  for (CMDF_Bit* pbit : m_renderedBits) {
     if (nullptr != pbit) {
       QString str = QString("Bit %1(%2)-- %3").arg(pbit->getPos()).arg(pbit->getWidth()).arg(pbit->getName().c_str());
       ui->listBits->addItem(str);
-      // Set data to register index
-      ui->listBits->item(ui->listBits->count() - 1)->setData(Qt::UserRole, pbit->getPos());
+      ui->listBits->item(ui->listBits->count() - 1)
+        ->setData(Qt::UserRole, QVariant::fromValue<quintptr>(reinterpret_cast<quintptr>(pbit)));
     }
   }
 }
@@ -233,21 +235,9 @@ CDlgMdfBitList::getBitList(void)
 //
 
 CMDF_Bit*
-CDlgMdfBitList::getBitObj(uint8_t pos)
+CDlgMdfBitList::getBitObj(quintptr key)
 {
-  std::deque<CMDF_Bit*>* pbits = getBitList();
-  if (nullptr == pbits) {
-    return nullptr;
-  }
-
-  for (auto it = pbits->cbegin(); it != pbits->cend(); ++it) {
-    CMDF_Bit* pbit = *it;
-    if (pbit->getPos() == pos) {
-      return pbit;
-    }
-  }
-
-  return nullptr;
+  return reinterpret_cast<CMDF_Bit*>(key);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -348,7 +338,7 @@ CDlgMdfBitList::editRegisterBit(void)
     }
 
     // Get the bit
-    pbit = getBitObj(pitem->data(Qt::UserRole).toUInt());
+    pbit = getBitObj(pitem->data(Qt::UserRole).value<quintptr>());
     if (nullptr == pbit) {
       return;
     }
@@ -399,8 +389,9 @@ CDlgMdfBitList::dupRegisterBit(void)
     }
 
     // Get the bit
-    pbit = getBitObj(pitem->data(Qt::UserRole).toUInt());
+    pbit = getBitObj(pitem->data(Qt::UserRole).value<quintptr>());
     if (nullptr == pbit) {
+      delete pbitnew;
       return;
     }
 
@@ -408,7 +399,7 @@ CDlgMdfBitList::dupRegisterBit(void)
     *pbitnew = *pbit;
 
     CDlgMdfBit dlg(this);
-    dlg.initDialogData(pbit, 0, m_type);
+    dlg.initDialogData(pbitnew, 0, m_type);
     // dupbitdlg:
     if (QDialog::Accepted == dlg.exec()) {
       // uint8_t mask;
@@ -419,6 +410,7 @@ CDlgMdfBitList::dupRegisterBit(void)
 
       // Get bitlist (for type)
       if (nullptr == (pbits = getBitList())) {
+        delete pbitnew;
         return;
       }
 
@@ -457,15 +449,20 @@ CDlgMdfBitList::deleteRegisterBit(void)
 
     QListWidgetItem* pitem = ui->listBits->currentItem();
 
-    for (auto it = pbits->cbegin(); it != pbits->cend(); ++it) {
-      CMDF_Bit* pbit = *it;
-      if (pbit->getPos() == pitem->data(Qt::UserRole).toUInt()) {
+    CMDF_Bit* pDelete = getBitObj(pitem->data(Qt::UserRole).value<quintptr>());
+    for (auto it = pbits->begin(); it != pbits->end(); ++it) {
+      if (*it == pDelete) {
         pbits->erase(it);
+        delete pDelete;
+        break;
       }
     }
 
     ui->listBits->clear();
     renderBitItems();
+    if (pbits->empty()) {
+      return;
+    }
     size_t sel = idx;
     if (0 == idx) {
       sel = 0;

--- a/src/cdlgmdfbitlist.cpp
+++ b/src/cdlgmdfbitlist.cpp
@@ -189,7 +189,7 @@ CDlgMdfBitList::renderBitItems(void)
 
   std::stable_sort(m_renderedBits.begin(),
                    m_renderedBits.end(),
-                   [](const CMDF_Bit* a, const CMDF_Bit* b) { return a->getPos() < b->getPos(); });
+                   [](CMDF_Bit* a, CMDF_Bit* b) { return a->getPos() < b->getPos(); });
 
   for (CMDF_Bit* pbit : m_renderedBits) {
     if (nullptr != pbit) {

--- a/src/cdlgmdfbitlist.h
+++ b/src/cdlgmdfbitlist.h
@@ -35,6 +35,7 @@
 #include "cdlgmdfregister.h"
 
 #include <QDialog>
+#include <vector>
 
 namespace Ui {
 class CDlgMdfBitList;
@@ -81,7 +82,7 @@ public:
     @param pos The bits start position
     @return Pointer to bit object or null pointer if pos is invalid
   */
-  CMDF_Bit* getBitObj(uint8_t pos);
+  CMDF_Bit* getBitObj(quintptr key);
 
   /*!
     Check if bits overlap
@@ -123,8 +124,7 @@ private:
   mdf_record_type m_type;
 
   // Render data
-  std::set<uint8_t> m_bitset;
-  std::map<uint8_t, CMDF_Bit*> m_bitmap;
+  std::vector<CMDF_Bit*> m_renderedBits;
 };
 
 #endif // CDLGMDFREGISTERBITLIST_H

--- a/src/cdlgmdfdm.cpp
+++ b/src/cdlgmdfdm.cpp
@@ -135,6 +135,7 @@ CDlgMdfDM::initDialogData(CMDF* pmdf, CMDF_DecisionMatrix* pdm, int index)
           SIGNAL(clicked()),
           this,
           SLOT(deleteAction()));
+  connect(ui->listActions, &QListWidget::doubleClicked, this, &CDlgMdfDM::editAction);
 
   setLevel(pmdf->getLevel());
   ui->comboLevel->setEnabled(false);
@@ -337,6 +338,9 @@ CDlgMdfDM::addAction(void)
   int idx = ui->listActions->currentRow();
 
   QListWidgetItem* pitem = ui->listActions->currentItem();
+  if (nullptr == pitem) {
+    return;
+  }
   CMDF_Action* paction   = new CMDF_Action; // = m_pdm->getAction(pitem->data(QListWidgetItem::UserType).toUInt());
   if (nullptr == paction) {
     return;
@@ -372,6 +376,9 @@ CDlgMdfDM::dupAction(void)
   int idx = ui->listActions->currentRow();
 
   QListWidgetItem* pitem = ui->listActions->currentItem();
+  if (nullptr == pitem) {
+    return;
+  }
   CMDF_Action* paction   = m_pdm->getAction(pitem->data(QListWidgetItem::UserType).toUInt());
   if (nullptr == paction) {
     return;
@@ -402,7 +409,7 @@ adddlg:
     ui->listActions->setCurrentRow(idx);
   }
   else {
-    delete paction;
+    delete pactionnew;
   }
 }
 
@@ -419,6 +426,9 @@ CDlgMdfDM::deleteAction(void)
   int idx = ui->listActions->currentRow();
 
   QListWidgetItem* pitem = ui->listActions->currentItem();
+  if (nullptr == pitem) {
+    return;
+  }
   CMDF_Action* paction   = m_pdm->getAction(pitem->data(QListWidgetItem::UserType).toUInt());
   if (nullptr == paction) {
     return;

--- a/src/cdlgmdfregisterlist.cpp
+++ b/src/cdlgmdfregisterlist.cpp
@@ -41,11 +41,13 @@
 #include "ui_cdlgmdfregisterlist.h"
 
 #include <QDebug>
-#include <QInputDialog>
 #include <QMessageBox>
-#include <QPushButton>
 #include <QDesktopServices>
+#include <QInputDialog>
+#include <QPushButton>
 #include <QShortcut>
+
+#include <algorithm>
 
 #include <spdlog/async.h>
 #include <spdlog/sinks/rotating_file_sink.h>
@@ -154,46 +156,36 @@ CDlgMdfRegisterList::renderComboPage(void)
 void
 CDlgMdfRegisterList::renderRegisterItems(void)
 {
-  std::map<uint32_t, CMDF_Register*> pages;
-
   if (nullptr == m_pmdf) {
     return;
   }
 
   ui->listRegister->clear();
-
-  // Make sorted set of registers on this page
-  std::deque<CMDF_Register*>* regset = m_pmdf->getRegisterObjList();
-  for (auto it = regset->cbegin(); it != regset->cend(); ++it) {
-    if (m_page == (*it)->getPage()) {
-      m_registersSet.insert((*it)->getOffset());
-    }
-  }
-
-  m_pmdf->getRegisterMap(m_page, pages);
+  m_renderedRegisters.clear();
 
   std::deque<CMDF_Register*>* regs = m_pmdf->getRegisterObjList();
+  if (nullptr == regs) {
+    return;
+  }
 
-  for (auto it = m_registersSet.cbegin(); it != m_registersSet.cend(); ++it) {
-    // m_registersSet.insert((*it)->getOffset());
-    CMDF_Register* preg = m_pmdf->getRegister(*it, m_page);
-    if (nullptr != preg) {
-      QString str = QString("Register  %1 -- %2").arg(preg->getOffset()).arg(preg->getName().c_str());
-      ui->listRegister->addItem(str);
-      // Set data to register index
-      ui->listRegister->item(ui->listRegister->count() - 1)->setData(Qt::UserRole, preg->getOffset());
+  for (CMDF_Register* preg : *regs) {
+    if ((nullptr != preg) && (m_page == preg->getPage())) {
+      m_renderedRegisters.push_back(preg);
     }
   }
 
-  // for (auto it = regs->cbegin(); it != regs->cend(); ++it) {
-  //   m_registersSet.insert((*it)->getOffset());
-  //   if ((*it)->getPage() == m_page) {
-  //     QString str = QString("Register  %1 -- %2").arg((*it)->getOffset()).arg((*it)->getName().c_str());
-  //     ui->listRegister->addItem(str);
-  //     // Set data to register index
-  //     ui->listRegister->item(ui->listRegister->count() - 1)->setData(Qt::UserRole, (*it)->getOffset());
-  //   }
-  // }
+  std::stable_sort(m_renderedRegisters.begin(),
+                   m_renderedRegisters.end(),
+                   [](const CMDF_Register* a, const CMDF_Register* b) {
+                     return a->getOffset() < b->getOffset();
+                   });
+
+  for (CMDF_Register* preg : m_renderedRegisters) {
+    QString str = QString("Register  %1 -- %2").arg(preg->getOffset()).arg(preg->getName().c_str());
+    ui->listRegister->addItem(str);
+    ui->listRegister->item(ui->listRegister->count() - 1)
+      ->setData(Qt::UserRole, QVariant::fromValue<quintptr>(reinterpret_cast<quintptr>(preg)));
+  }
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -245,9 +237,6 @@ addregdlg:
     }
     qDebug() << "Page=" << pregnew->getPage() << " Offset=" << pregnew->getOffset();
     m_pmdf->getRegisterObjList()->push_back(pregnew);
-    if (m_page == pregnew->getPage()) {
-      m_registersSet.insert(pregnew->getOffset());
-    }
     ui->listRegister->clear();
     renderRegisterItems();
     if (-1 != idx) {
@@ -281,7 +270,10 @@ CDlgMdfRegisterList::editRegister(void)
     int idx = ui->listRegister->currentRow();
 
     QListWidgetItem* pitem = ui->listRegister->currentItem();
-    CMDF_Register* preg    = m_pmdf->getRegister(pitem->data(Qt::UserRole).toUInt(), m_page);
+    CMDF_Register* preg = reinterpret_cast<CMDF_Register*>(pitem->data(Qt::UserRole).value<quintptr>());
+    if (nullptr == preg) {
+      return;
+    }
 
     CDlgMdfRegister dlg(this);
     dlg.initDialogData(m_pmdf, preg);
@@ -311,7 +303,10 @@ CDlgMdfRegisterList::dupRegister(void)
     int idx = ui->listRegister->currentRow();
 
     QListWidgetItem* pitem = ui->listRegister->currentItem();
-    CMDF_Register* preg    = m_pmdf->getRegister(pitem->data(Qt::UserRole).toUInt(), m_page);
+    CMDF_Register* preg = reinterpret_cast<CMDF_Register*>(pitem->data(Qt::UserRole).value<quintptr>());
+    if (nullptr == preg) {
+      return;
+    }
 
     CMDF_Register* pregnew = new CMDF_Register();
     pregnew->setPage(m_page);
@@ -331,9 +326,6 @@ CDlgMdfRegisterList::dupRegister(void)
       }
       qDebug() << "Page=" << pregnew->getPage() << " Offset=" << pregnew->getOffset();
       m_pmdf->getRegisterObjList()->push_back(pregnew);
-      if (m_page == pregnew->getPage()) {
-        m_registersSet.insert(pregnew->getOffset());
-      }
       ui->listRegister->clear();
       renderRegisterItems();
       if (-1 != idx) {
@@ -402,7 +394,10 @@ CDlgMdfRegisterList::deleteRegister(void)
     int idx = ui->listRegister->currentRow();
 
     QListWidgetItem* pitem = ui->listRegister->currentItem();
-    CMDF_Register* preg    = m_pmdf->getRegister(pitem->data(Qt::UserRole).toUInt(), m_page);
+    CMDF_Register* preg = reinterpret_cast<CMDF_Register*>(pitem->data(Qt::UserRole).value<quintptr>());
+    if (nullptr == preg) {
+      return;
+    }
     m_pmdf->deleteRegister(preg);
     // delete preg;
     ui->listRegister->removeItemWidget(pitem);

--- a/src/cdlgmdfregisterlist.cpp
+++ b/src/cdlgmdfregisterlist.cpp
@@ -176,7 +176,7 @@ CDlgMdfRegisterList::renderRegisterItems(void)
 
   std::stable_sort(m_renderedRegisters.begin(),
                    m_renderedRegisters.end(),
-                   [](const CMDF_Register* a, const CMDF_Register* b) {
+                   [](CMDF_Register* a, CMDF_Register* b) {
                      return a->getOffset() < b->getOffset();
                    });
 

--- a/src/cdlgmdfregisterlist.h
+++ b/src/cdlgmdfregisterlist.h
@@ -35,6 +35,7 @@
 #include "cdlgmdfregister.h"
 
 #include <QDialog>
+#include <vector>
 
 namespace Ui {
 class CDlgMdfRegisterList;
@@ -108,8 +109,8 @@ private:
   // Register page
   uint16_t m_page;
 
-  // Used to get a sorted list of registers
-  std::set<uint32_t> m_registersSet;
+  // Registers currently rendered in the list
+  std::vector<CMDF_Register*> m_renderedRegisters;
 };
 
 #endif // CDLGMDFREGISTERLIST_H

--- a/src/cfrmmdf.cpp
+++ b/src/cfrmmdf.cpp
@@ -77,6 +77,8 @@
 
 #include <QClipboard>
 #include <QDate>
+#include <QDateTime>
+#include <QDir>
 #include <QFile>
 #include <QFileInfo>
 #include <QJSEngine>
@@ -84,8 +86,11 @@
 #include <QStandardPaths>
 #include <QTableView>
 #include <QTableWidgetItem>
+#include <QTimer>
 #include <QXmlStreamReader>
 #include <QtWidgets>
+
+#include <algorithm>
 
 // ----------------------------------------------------------------------------
 
@@ -284,6 +289,14 @@ CFrmMdf::CFrmMdf(QWidget* parent, const char* path)
           this,
           &CFrmMdf::onItemDoubleClicked);
 
+  m_autoSaveTimer = new QTimer(this);
+  connect(m_autoSaveTimer, &QTimer::timeout, this, &CFrmMdf::onAutoSaveTimeout);
+
+  if (pworks->m_mdfAutoSaveEnabled) {
+    const int intervalMs = qMax(10, static_cast<int>(pworks->m_mdfAutoSaveInterval)) * 1000;
+    m_autoSaveTimer->start(intervalMs);
+  }
+
   this->setFixedSize(this->size());
 
   newMdf(); // Render defaults
@@ -464,7 +477,14 @@ void
 CFrmMdf::saveMdf()
 {
   if (m_last_path.isEmpty()) {
-    QMessageBox::warning(this, APPNAME, tr("No opened MDF file to save."));
+    QString path = QFileDialog::getSaveFileName(this,
+                                                tr("Save Module Description File (MDF)"),
+                                                "",
+                                                tr("MDF Files (*.mdf *.json *.xml);;All Files (*.*)"));
+    if (path.isEmpty()) {
+      return;
+    }
+    saveMdfToPath(path, detectMdfFormatForPath(path));
     return;
   }
 
@@ -492,6 +512,10 @@ CFrmMdf::saveMdfToPath(const QString& path, mdf_format format)
     return false;
   }
 
+  if ((MDF_FORMAT_JSON == format) && !enrichSavedJsonWithDecisionMatrix(path)) {
+    return false;
+  }
+
   m_last_path = path;
   m_labelOpenedFile->setText(tr("File: %1").arg(path));
   ui->statusbar->showMessage(tr("Saved %1").arg(path), 2000);
@@ -507,24 +531,217 @@ CFrmMdf::createBackupForPath(const QString& path)
     return true;
   }
 
-  const QString backupPath = path + ".bak";
-  if (QFile::exists(backupPath) && !QFile::remove(backupPath)) {
-    QMessageBox::warning(this,
-                         APPNAME,
-                         tr("Failed to create backup.\n\nWhere: %1\nWhat: Unable to remove existing backup.")
-                           .arg(backupPath));
-    return false;
+  vscpworks* pworks = (vscpworks*)QCoreApplication::instance();
+  if (!pworks->m_mdfCumulativeBackups) {
+    const QString backupPath = path + ".bak";
+    if (QFile::exists(backupPath) && !QFile::remove(backupPath)) {
+      QMessageBox::warning(this,
+                           APPNAME,
+                           tr("Failed to create backup.\n\nWhere: %1\nWhat: Unable to remove existing backup.")
+                             .arg(backupPath));
+      return false;
+    }
+
+    if (!QFile::copy(path, backupPath)) {
+      QMessageBox::warning(this,
+                           APPNAME,
+                           tr("Failed to create backup.\n\nWhere: %1\nWhat: Unable to copy current file.")
+                             .arg(path));
+      return false;
+    }
+
+    return true;
   }
+
+  QFileInfo fi(path);
+  const QString backupPath = QString("%1/%2.bak.%3")
+                               .arg(fi.absolutePath(),
+                                    fi.fileName(),
+                                    QDateTime::currentDateTime().toString("yyyyMMdd-HHmmss-zzz"));
 
   if (!QFile::copy(path, backupPath)) {
     QMessageBox::warning(this,
                          APPNAME,
-                         tr("Failed to create backup.\n\nWhere: %1\nWhat: Unable to copy current file.")
+                         tr("Failed to create cumulative backup.\n\nWhere: %1\nWhat: Unable to copy current file.")
                            .arg(path));
     return false;
   }
 
+  if (pworks->m_mdfMaxBackups > 0) {
+    QDir dir(fi.absolutePath());
+    const QStringList entries = dir.entryList(QStringList() << QString("%1.bak.*").arg(fi.fileName()),
+                                              QDir::Files,
+                                              QDir::Name);
+    const int maxBackups = static_cast<int>(pworks->m_mdfMaxBackups);
+    const int removeCount = entries.size() - maxBackups;
+    for (int i = 0; i < removeCount; ++i) {
+      dir.remove(entries.at(i));
+    }
+  }
+
   return true;
+}
+
+bool
+CFrmMdf::enrichSavedJsonWithDecisionMatrix(const QString& path)
+{
+  QFile file(path);
+  if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+    QMessageBox::warning(this,
+                         APPNAME,
+                         tr("Failed to save MDF file.\n\nWhere: %1\nWhat: Unable to read saved JSON.")
+                           .arg(path));
+    return false;
+  }
+
+  json root;
+  try {
+    root = json::parse(file.readAll().toStdString());
+  }
+  catch (const std::exception &ex) {
+    QMessageBox::warning(this,
+                         APPNAME,
+                         tr("Failed to update JSON MDF with decision matrix data.\n\nWhere: %1\nWhat: %2")
+                           .arg(path)
+                           .arg(QString::fromUtf8(ex.what())));
+    return false;
+  }
+
+  if (!root.contains("module") || !root["module"].is_object()) {
+    QMessageBox::warning(this,
+                         APPNAME,
+                         tr("Failed to update JSON MDF with decision matrix data.\n\nWhere: %1\nWhat: Missing 'module' object.")
+                           .arg(path));
+    return false;
+  }
+
+  json &module = root["module"];
+  CMDF_DecisionMatrix* pdm = m_mdf.getDM();
+  if (nullptr != pdm) {
+    json jdm;
+    jdm["level"]        = pdm->getLevel();
+    jdm["start-page"]   = pdm->getStartPage();
+    jdm["start-offset"] = pdm->getStartOffset();
+    jdm["rowcnt"]       = pdm->getRowCount();
+    jdm["rowsize"]      = pdm->getRowSize();
+
+    json actions = json::array();
+    std::deque<CMDF_Action*>* pActionList = pdm->getActionList();
+    if (nullptr != pActionList) {
+      for (CMDF_Action* pAction : *pActionList) {
+        if (nullptr == pAction) {
+          continue;
+        }
+
+        json jaction;
+        jaction["name"] = pAction->getName();
+        jaction["code"] = pAction->getCode();
+
+        json params = json::array();
+        std::deque<CMDF_ActionParameter*>* pParams = pAction->getListActionParameter();
+        if (nullptr != pParams) {
+          for (CMDF_ActionParameter* pParam : *pParams) {
+            if (nullptr == pParam) {
+              continue;
+            }
+
+            json jparam;
+            jparam["name"]   = pParam->getName();
+            jparam["offset"] = pParam->getOffset();
+            jparam["min"]    = pParam->getMin();
+            jparam["max"]    = pParam->getMax();
+
+            json bits = json::array();
+            std::deque<CMDF_Bit*>* pBits = pParam->getListBits();
+            if (nullptr != pBits) {
+              for (CMDF_Bit* pBit : *pBits) {
+                if (nullptr == pBit) {
+                  continue;
+                }
+                json jbit;
+                jbit["name"]    = pBit->getName();
+                jbit["pos"]     = pBit->getPos();
+                jbit["width"]   = pBit->getWidth();
+                jbit["default"] = pBit->getDefault();
+                jbit["min"]     = pBit->getMin();
+                jbit["max"]     = pBit->getMax();
+
+                QString access;
+                if (2 & pBit->getAccess()) {
+                  access += "r";
+                }
+                if (1 & pBit->getAccess()) {
+                  access += "w";
+                }
+                jbit["access"] = access.toStdString();
+                bits.push_back(jbit);
+              }
+            }
+            if (!bits.empty()) {
+              jparam["bit"] = bits;
+            }
+
+            json values = json::array();
+            std::deque<CMDF_Value*>* pValues = pParam->getListValues();
+            if (nullptr != pValues) {
+              for (CMDF_Value* pValue : *pValues) {
+                if (nullptr == pValue) {
+                  continue;
+                }
+                json jvalue;
+                jvalue["name"]  = pValue->getName();
+                jvalue["value"] = pValue->getValue();
+                values.push_back(jvalue);
+              }
+            }
+            if (!values.empty()) {
+              jparam["valuelist"] = values;
+            }
+
+            params.push_back(jparam);
+          }
+        }
+
+        if (!params.empty()) {
+          jaction["param"] = params;
+        }
+
+        actions.push_back(jaction);
+      }
+    }
+
+    jdm["action"] = actions;
+    module["dmatrix"] = jdm;
+  }
+  else {
+    module.erase("dmatrix");
+  }
+
+  if (!file.close()) {
+    return false;
+  }
+
+  if (!file.open(QIODevice::WriteOnly | QIODevice::Text | QIODevice::Truncate)) {
+    QMessageBox::warning(this,
+                         APPNAME,
+                         tr("Failed to save MDF file.\n\nWhere: %1\nWhat: Unable to write updated JSON.")
+                           .arg(path));
+    return false;
+  }
+  file.write(QString::fromStdString(root.dump(2)).toUtf8());
+  file.close();
+
+  return true;
+}
+
+void
+CFrmMdf::onAutoSaveTimeout()
+{
+  if (m_last_path.isEmpty()) {
+    return;
+  }
+
+  saveMdfToPath(m_last_path, detectMdfFormatForPath(m_last_path));
 }
 
 void
@@ -1234,19 +1451,18 @@ CFrmMdf::renderBits(QTreeWidgetItem* pParent, std::deque<CMDF_Bit*>& dequebits, 
     return;
   }
 
-  // Create set with sorted bit offsets and a map
-  // to help find corresponding bit pointer
-  // Add registers for page
-  std::set<uint8_t> bitset;
-  std::map<uint8_t, CMDF_Bit*> bitmap;
-  for (auto it = dequebits.cbegin(); it != dequebits.cend(); ++it) {
-    bitset.insert((*it)->getPos());
-    bitmap[(*it)->getPos()] = *it;
+  std::vector<CMDF_Bit*> orderedBits;
+  orderedBits.reserve(dequebits.size());
+  for (CMDF_Bit* pbit : dequebits) {
+    if (nullptr != pbit) {
+      orderedBits.push_back(pbit);
+    }
   }
+  std::stable_sort(orderedBits.begin(),
+                   orderedBits.end(),
+                   [](const CMDF_Bit* a, const CMDF_Bit* b) { return a->getPos() < b->getPos(); });
 
-  for (auto it2 = bitset.cbegin(); it2 != bitset.cend(); ++it2) {
-
-    CMDF_Bit* pbit = bitmap[*it2];
+  for (CMDF_Bit* pbit : orderedBits) {
 
     str = QString("Bits:{");
     for (int j = pbit->getPos(); j < qMin(8, pbit->getPos() + pbit->getWidth()); j++) {
@@ -1481,66 +1697,55 @@ CFrmMdf::renderRegisterItem(QTreeWidgetItem* pParent, CMDF_Register* preg)
 void
 CFrmMdf::renderRegisters(QTreeWidgetItem* pParent)
 {
-  uint32_t nPages;
-  std::set<uint16_t> pages;
-  QMdfTreeWidgetItem* pSubItem;
-  QMdfTreeWidgetItem* pItem = nullptr;
-
   // Check pointers
   if (nullptr == pParent) {
     return;
   }
 
-  // Fetch number of pages and pages
-  nPages                           = m_mdf.getPages(pages);
   std::deque<CMDF_Register*>* regs = m_mdf.getRegisterObjList();
+  if ((nullptr == regs) || regs->empty()) {
+    return;
+  }
 
-  // If we have pages separate registers in pages
-  if (nPages >= 1) {
-    for (auto itr : pages) {
-
-      pItem = new QMdfTreeWidgetItem(pParent, &m_mdf, mdf_type_register_page, itr);
-      if (nullptr != pItem) {
-
-        QString str = QString(tr("Register page: %1")).arg(itr);
-        pItem->setText(0, str);
-        pItem->setData(0, Qt::UserRole, itr); // Save page
-        pParent->addChild(pItem);
-
-        // Add registers for page
-        std::set<uint32_t> regset;
-        std::map<uint32_t, CMDF_Register*> regmap;
-
-        // Create set with sorted register offsets and a map
-        // to help find corresponding register pointer
-        for (auto it = regs->cbegin(); it != regs->cend(); ++it) {
-          if (itr == (*it)->getPage()) {
-            regset.insert((*it)->getOffset());
-            regmap[(*it)->getOffset()] = *it;
-          }
-        }
-
-        // Render register sorted on offset for a register page
-        for (auto it = regset.cbegin(); it != regset.cend(); ++it) {
-          CMDF_Register* preg = regmap[*it];
-          pSubItem            = new QMdfTreeWidgetItem(pItem, preg, mdf_type_register_item);
-          if (nullptr != pSubItem) {
-            str = QString("Register  %1 %2").arg(preg->getOffset()).arg(preg->getName().c_str());
-            pSubItem->setText(0, str);
-            pItem->addChild(pSubItem);
-            renderRegisterItem(pSubItem, preg);
-          }
-        }
-
-        // pItem->sortChildren(0,Qt::AscendingOrder);
-      }
+  std::map<uint16_t, std::vector<CMDF_Register*>> registersByPage;
+  for (CMDF_Register* preg : *regs) {
+    if (nullptr != preg) {
+      registersByPage[preg->getPage()].push_back(preg);
     }
   }
-  // We only have one page
-  else {
-    std::map<uint32_t, CMDF_Register*> mapRegs;
-    m_mdf.getRegisterMap(0, mapRegs);
-    renderRegisterItem(pItem, mapRegs[0]);
+
+  for (auto &entry : registersByPage) {
+    const uint16_t page = entry.first;
+    std::vector<CMDF_Register*>& pageRegisters = entry.second;
+
+    std::stable_sort(pageRegisters.begin(),
+                     pageRegisters.end(),
+                     [](const CMDF_Register* a, const CMDF_Register* b) {
+                       return a->getOffset() < b->getOffset();
+                     });
+
+    QMdfTreeWidgetItem* pItem = new QMdfTreeWidgetItem(pParent, &m_mdf, mdf_type_register_page, page);
+    if (nullptr == pItem) {
+      continue;
+    }
+
+    pItem->setText(0, QString(tr("Register page: %1")).arg(page));
+    pItem->setData(0, Qt::UserRole, page); // Save page
+    pParent->addChild(pItem);
+
+    for (CMDF_Register* preg : pageRegisters) {
+      QMdfTreeWidgetItem* pSubItem = new QMdfTreeWidgetItem(pItem, preg, mdf_type_register_item);
+      if (nullptr == pSubItem) {
+        continue;
+      }
+
+      pSubItem->setText(0, QString("Register  %1 %2").arg(preg->getOffset()).arg(preg->getName().c_str()));
+      pSubItem->setData(0,
+                        Qt::UserRole,
+                        QVariant::fromValue<quintptr>(reinterpret_cast<quintptr>(preg)));
+      pItem->addChild(pSubItem);
+      renderRegisterItem(pSubItem, preg);
+    }
   }
 }
 

--- a/src/cfrmmdf.cpp
+++ b/src/cfrmmdf.cpp
@@ -717,9 +717,7 @@ CFrmMdf::enrichSavedJsonWithDecisionMatrix(const QString& path)
     module.erase("dmatrix");
   }
 
-  if (!file.close()) {
-    return false;
-  }
+  file.close();
 
   if (!file.open(QIODevice::WriteOnly | QIODevice::Text | QIODevice::Truncate)) {
     QMessageBox::warning(this,
@@ -1460,7 +1458,7 @@ CFrmMdf::renderBits(QTreeWidgetItem* pParent, std::deque<CMDF_Bit*>& dequebits, 
   }
   std::stable_sort(orderedBits.begin(),
                    orderedBits.end(),
-                   [](const CMDF_Bit* a, const CMDF_Bit* b) { return a->getPos() < b->getPos(); });
+                   [](CMDF_Bit* a, CMDF_Bit* b) { return a->getPos() < b->getPos(); });
 
   for (CMDF_Bit* pbit : orderedBits) {
 
@@ -1720,7 +1718,7 @@ CFrmMdf::renderRegisters(QTreeWidgetItem* pParent)
 
     std::stable_sort(pageRegisters.begin(),
                      pageRegisters.end(),
-                     [](const CMDF_Register* a, const CMDF_Register* b) {
+                     [](CMDF_Register* a, CMDF_Register* b) {
                        return a->getOffset() < b->getOffset();
                      });
 

--- a/src/cfrmmdf.h
+++ b/src/cfrmmdf.h
@@ -45,6 +45,7 @@
 #include <QMenu>
 #include <QObject>
 #include <QStringList>
+#include <QTimer>
 #include <QTreeWidget>
 #include <QTreeWidgetItem>
 
@@ -616,9 +617,11 @@ public slots:
   void saveMdf(void);
   bool saveMdfToPath(const QString& path, mdf_format format);
   bool createBackupForPath(const QString& path);
+  bool enrichSavedJsonWithDecisionMatrix(const QString& path);
   void addRecentSavedFile(const QString& path);
   void loadRecentSavedFiles();
   void rebuildRecentSavedFilesMenu();
+  void onAutoSaveTimeout();
 
   /*!
     Find next MDF type item in tree
@@ -687,6 +690,7 @@ private:
   QString m_last_path;
   QStringList m_recentSavedFiles;
   QMenu* m_menuRecentSaved = nullptr;
+  QTimer* m_autoSaveTimer  = nullptr;
 
   /// True if a loadeed file has been edited
   bool m_bChanged;

--- a/src/vscpworks.cpp
+++ b/src/vscpworks.cpp
@@ -80,6 +80,10 @@ vscpworks::vscpworks(int& argc, char** argv)
   m_bAskBeforeDelete  = true;
   m_bEnableDarkTheme  = false;
   m_bSaveAlwaysJSON   = false;
+  m_mdfAutoSaveEnabled = false;
+  m_mdfAutoSaveInterval = 300;
+  m_mdfCumulativeBackups = false;
+  m_mdfMaxBackups = 10;
 
   m_session_timeout   = 1000;
   m_session_maxEvents = -1;
@@ -519,6 +523,22 @@ vscpworks::loadSettings(void)
     m_firmware_devicecode_required = j["firmwareDeviceCodeRequired"].get<bool>();
   }
 
+  if (j.contains("mdfAutoSaveEnabled") && j["mdfAutoSaveEnabled"].is_boolean()) {
+    m_mdfAutoSaveEnabled = j["mdfAutoSaveEnabled"].get<bool>();
+  }
+
+  if (j.contains("mdfAutoSaveInterval") && j["mdfAutoSaveInterval"].is_number_unsigned()) {
+    m_mdfAutoSaveInterval = j["mdfAutoSaveInterval"].get<uint32_t>();
+  }
+
+  if (j.contains("mdfCumulativeBackups") && j["mdfCumulativeBackups"].is_boolean()) {
+    m_mdfCumulativeBackups = j["mdfCumulativeBackups"].get<bool>();
+  }
+
+  if (j.contains("mdfMaxBackups") && j["mdfMaxBackups"].is_number_unsigned()) {
+    m_mdfMaxBackups = j["mdfMaxBackups"].get<uint32_t>();
+  }
+
   // VSCP event database last load date/time
   // ---------------------------------------
   if (j.contains("last-eventdb-download") && j["last-eventdb-download"].is_number()) {
@@ -668,6 +688,12 @@ vscpworks::writeSettings()
 
   // * * * Firmware * * *
   j["firmwareDeviceCodeRequired"] = m_firmware_devicecode_required;
+
+  // * * * MDF editor * * *
+  j["mdfAutoSaveEnabled"]  = m_mdfAutoSaveEnabled;
+  j["mdfAutoSaveInterval"] = m_mdfAutoSaveInterval;
+  j["mdfCumulativeBackups"] = m_mdfCumulativeBackups;
+  j["mdfMaxBackups"] = m_mdfMaxBackups;
 
   QMap<std::string, json>::const_iterator it = m_mapConn.constBegin();
   while (it != m_mapConn.constEnd()) {

--- a/src/vscpworks.h
+++ b/src/vscpworks.h
@@ -410,6 +410,18 @@ public:
   */
   bool m_bSaveAlwaysJSON;
 
+  /// Enable periodic autosave for MDF editor windows
+  bool m_mdfAutoSaveEnabled;
+
+  /// Autosave interval for MDF editor (seconds)
+  uint32_t m_mdfAutoSaveInterval;
+
+  /// If true, MDF backups are timestamped and cumulative
+  bool m_mdfCumulativeBackups;
+
+  /// Max number of cumulative MDF backups kept per file (0 = unlimited)
+  uint32_t m_mdfMaxBackups;
+
   //**************************************************************************
   //                            LOGGER (SPDLOG)
   //**************************************************************************


### PR DESCRIPTION
## Summary
This PR fixes MDF editor issues #14, #15, #16, #17, #18, #19, and #20, and adds configurable cumulative backups.

### Included fixes
- Fix register rendering/list handling so duplicate offsets no longer corrupt or hide following entries.
- Fix bit rendering/list handling so duplicate bit positions no longer corrupt structure or target the wrong item.
- Enable double-click editing in the DM action list.
- Improve `Save` behavior: if no current file exists, it now prompts with Save As flow.
- Add MDF autosave support with configurable interval.
- Add configurable cumulative MDF backups (timestamped) with retention cap.
- Ensure Decision Matrix data is written to JSON saves.

## Configuration additions
- `mdfAutoSaveEnabled`
- `mdfAutoSaveInterval`
- `mdfCumulativeBackups`
- `mdfMaxBackups`

## Notes
- Build could not be executed in this environment because Qt6 is not installed (`Qt6Config.cmake` missing).