### PR TITLE
Fix #11: Add realtime measurement visualization windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,6 +250,8 @@ qt_add_executable(${PROJECT_NAME}
 
   src/cfrmsession.h
   src/cfrmsession.cpp
+  src/cfrmmeasurementview.h
+  src/cfrmmeasurementview.cpp
   src/cfrmmqttexplorer.h
   src/cfrmmqttexplorer.cpp
   src/cfrmrawcansession.h

--- a/src/cfrmmeasurementview.cpp
+++ b/src/cfrmmeasurementview.cpp
@@ -1,0 +1,384 @@
+// cfrmmeasurementview.cpp
+//
+// This file is part of the VSCP (https://www.vscp.org)
+//
+// The MIT License (MIT)
+//
+// Copyright (C) 2000-2026 Ake Hedman, Grodans Paradis AB
+// <info@grodansparadis.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+#include "cfrmmeasurementview.h"
+
+#include <QComboBox>
+#include <QDateTime>
+#include <QDial>
+#include <QFile>
+#include <QFileDialog>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QMessageBox>
+#include <QProgressBar>
+#include <QPushButton>
+#include <QPainter>
+#include <QStackedWidget>
+#include <QTextStream>
+#include <QVBoxLayout>
+#include <QtCharts/QChart>
+#include <QtCharts/QChartView>
+#include <QtCharts/QLineSeries>
+#include <QtCharts/QValueAxis>
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+
+bool
+CMeasurementSourceSpec::matches(const vscp_event_t* pev) const
+{
+  if (nullptr == pev) {
+    return false;
+  }
+
+  if (!vscp_isMeasurement(pev)) {
+    return false;
+  }
+
+  if ((pev->vscp_class != vscpClass) || (pev->vscp_type != vscpType)) {
+    return false;
+  }
+
+  if (vscp_getMeasurementSensorIndex(pev) != sensorIndex) {
+    return false;
+  }
+
+  if (vscp_getMeasurementUnit(pev) != unit) {
+    return false;
+  }
+
+  return !memcmp(pev->GUID, guid.data(), guid.size());
+}
+
+CFrmMeasurementView::CFrmMeasurementView(const CMeasurementSourceSpec& source,
+                                         const QString& sourceDescription,
+                                         QWidget* parent)
+  : QWidget(parent, Qt::Window)
+  , m_source(source)
+  , m_sourceDescription(sourceDescription)
+{
+  setAttribute(Qt::WA_DeleteOnClose, true);
+  setupUi();
+}
+
+CFrmMeasurementView::~CFrmMeasurementView()
+{
+}
+
+bool
+CFrmMeasurementView::matchesEvent(const vscp_event_t* pev) const
+{
+  return m_source.matches(pev);
+}
+
+void
+CFrmMeasurementView::appendMeasurement(const vscp_event_t* pev)
+{
+  if (!matchesEvent(pev)) {
+    return;
+  }
+
+  double value = 0;
+  if (vscp_getMeasurementAsDouble(&value, const_cast<vscp_event_t*>(pev))) {
+    return;
+  }
+
+  if (m_samples.empty()) {
+    m_minSeen = value;
+    m_maxSeen = value;
+  }
+  else {
+    m_minSeen = std::min(m_minSeen, value);
+    m_maxSeen = std::max(m_maxSeen, value);
+  }
+
+  measurementSample sample;
+  sample.timestamp = QDateTime::currentDateTimeUtc();
+  sample.value     = value;
+  m_samples.push_back(sample);
+
+  if (m_samples.size() > MAX_SAMPLES) {
+    m_samples.erase(m_samples.begin(), m_samples.begin() + (m_samples.size() - MAX_SAMPLES));
+  }
+
+  refreshDisplay(value);
+}
+
+void
+CFrmMeasurementView::setupUi()
+{
+  setWindowTitle(tr("Realtime Measurement"));
+  resize(860, 560);
+
+  QVBoxLayout* mainLayout = new QVBoxLayout(this);
+
+  QHBoxLayout* topLayout = new QHBoxLayout();
+  topLayout->addWidget(new QLabel(tr("Display mode:"), this));
+
+  m_modeCombo = new QComboBox(this);
+  m_modeCombo->addItem(tr("Diagram"));
+  m_modeCombo->addItem(tr("Value"));
+  m_modeCombo->addItem(tr("Speed meter"));
+  m_modeCombo->addItem(tr("Percent"));
+  topLayout->addWidget(m_modeCombo, 0);
+
+  topLayout->addStretch(1);
+
+  m_saveButton = new QPushButton(tr("Save..."), this);
+  topLayout->addWidget(m_saveButton);
+
+  m_clearButton = new QPushButton(tr("Clear"), this);
+  topLayout->addWidget(m_clearButton);
+
+  mainLayout->addLayout(topLayout);
+
+  m_sourceLabel = new QLabel(m_sourceDescription, this);
+  m_sourceLabel->setWordWrap(true);
+  mainLayout->addWidget(m_sourceLabel);
+
+  m_displayStack = new QStackedWidget(this);
+  mainLayout->addWidget(m_displayStack, 1);
+
+  // Diagram page
+  QWidget* pageDiagram    = new QWidget(this);
+  QVBoxLayout* diagLayout = new QVBoxLayout(pageDiagram);
+  m_chart                 = new QtCharts::QChart();
+  m_chart->legend()->hide();
+  m_chart->setTitle(tr("Measurement history"));
+  m_lineSeries = new QtCharts::QLineSeries();
+  m_chart->addSeries(m_lineSeries);
+  m_axisX = new QtCharts::QValueAxis();
+  m_axisX->setTitleText(tr("Sample"));
+  m_axisX->setRange(0, MAX_SAMPLES);
+  m_chart->addAxis(m_axisX, Qt::AlignBottom);
+  m_lineSeries->attachAxis(m_axisX);
+  m_axisY = new QtCharts::QValueAxis();
+  m_axisY->setTitleText(tr("Value"));
+  m_axisY->setRange(0, 100);
+  m_chart->addAxis(m_axisY, Qt::AlignLeft);
+  m_lineSeries->attachAxis(m_axisY);
+  QtCharts::QChartView* chartView = new QtCharts::QChartView(m_chart, pageDiagram);
+  chartView->setRenderHint(QPainter::Antialiasing);
+  diagLayout->addWidget(chartView);
+  m_displayStack->addWidget(pageDiagram);
+
+  // Value page
+  QWidget* pageValue      = new QWidget(this);
+  QVBoxLayout* valueLayout = new QVBoxLayout(pageValue);
+  m_valueLabel             = new QLabel("--", pageValue);
+  m_valueLabel->setAlignment(Qt::AlignCenter);
+  QFont valueFont = m_valueLabel->font();
+  valueFont.setPointSize(34);
+  valueFont.setBold(true);
+  m_valueLabel->setFont(valueFont);
+  valueLayout->addStretch(1);
+  valueLayout->addWidget(m_valueLabel);
+  valueLayout->addStretch(1);
+  m_displayStack->addWidget(pageValue);
+
+  // Speed meter page
+  QWidget* pageSpeed      = new QWidget(this);
+  QVBoxLayout* speedLayout = new QVBoxLayout(pageSpeed);
+  m_speedMeter             = new QDial(pageSpeed);
+  m_speedMeter->setNotchesVisible(true);
+  m_speedMeter->setWrapping(false);
+  m_speedMeter->setEnabled(false);
+  m_speedMeter->setRange(0, 100);
+  m_speedValueLabel = new QLabel("--", pageSpeed);
+  m_speedValueLabel->setAlignment(Qt::AlignCenter);
+  speedLayout->addStretch(1);
+  speedLayout->addWidget(m_speedMeter, 0, Qt::AlignCenter);
+  speedLayout->addWidget(m_speedValueLabel);
+  speedLayout->addStretch(1);
+  m_displayStack->addWidget(pageSpeed);
+
+  // Percent page
+  QWidget* pagePercent      = new QWidget(this);
+  QVBoxLayout* percentLayout = new QVBoxLayout(pagePercent);
+  m_percentBar               = new QProgressBar(pagePercent);
+  m_percentBar->setRange(0, 100);
+  m_percentBar->setTextVisible(false);
+  m_percentValueLabel = new QLabel("--", pagePercent);
+  m_percentValueLabel->setAlignment(Qt::AlignCenter);
+  percentLayout->addStretch(1);
+  percentLayout->addWidget(m_percentBar);
+  percentLayout->addWidget(m_percentValueLabel);
+  percentLayout->addStretch(1);
+  m_displayStack->addWidget(pagePercent);
+
+  connect(m_modeCombo,
+          QOverload<int>::of(&QComboBox::currentIndexChanged),
+          this,
+          &CFrmMeasurementView::setDisplayMode);
+  connect(m_saveButton, &QPushButton::clicked, this, &CFrmMeasurementView::saveSamples);
+  connect(m_clearButton, &QPushButton::clicked, this, &CFrmMeasurementView::clearSamples);
+}
+
+void
+CFrmMeasurementView::setDisplayMode(int index)
+{
+  m_mode = static_cast<displayMode>(index);
+  m_displayStack->setCurrentIndex(index);
+  if (!m_samples.empty()) {
+    refreshDisplay(m_samples.back().value);
+  }
+}
+
+void
+CFrmMeasurementView::refreshDisplay(double latestValue)
+{
+  refreshDiagram();
+  refreshValueDisplay(latestValue);
+  refreshSpeedMeterDisplay(latestValue);
+  refreshPercentDisplay(latestValue);
+}
+
+void
+CFrmMeasurementView::refreshDiagram()
+{
+  if (nullptr == m_lineSeries) {
+    return;
+  }
+
+  QVector<QPointF> points;
+  points.reserve(static_cast<int>(m_samples.size()));
+
+  for (size_t i = 0; i < m_samples.size(); ++i) {
+    points.push_back(QPointF(static_cast<qreal>(i), m_samples[i].value));
+  }
+
+  m_lineSeries->replace(points);
+
+  if (m_samples.empty()) {
+    m_axisX->setRange(0, MAX_SAMPLES);
+    m_axisY->setRange(0, 100);
+    return;
+  }
+
+  m_axisX->setRange(0, std::max(1.0, static_cast<double>(m_samples.size() - 1)));
+
+  double minY = m_minSeen;
+  double maxY = m_maxSeen;
+
+  if (std::fabs(maxY - minY) < 0.000001) {
+    minY -= 1.0;
+    maxY += 1.0;
+  }
+  else {
+    const double margin = (maxY - minY) * 0.1;
+    minY -= margin;
+    maxY += margin;
+  }
+
+  m_axisY->setRange(minY, maxY);
+}
+
+void
+CFrmMeasurementView::refreshValueDisplay(double value)
+{
+  if (nullptr == m_valueLabel) {
+    return;
+  }
+
+  m_valueLabel->setText(QString::number(value, 'f', 3));
+}
+
+void
+CFrmMeasurementView::refreshSpeedMeterDisplay(double value)
+{
+  if ((nullptr == m_speedMeter) || (nullptr == m_speedValueLabel)) {
+    return;
+  }
+
+  double minValue = m_minSeen;
+  double maxValue = m_maxSeen;
+  if (std::fabs(maxValue - minValue) < 0.000001) {
+    minValue -= 1.0;
+    maxValue += 1.0;
+  }
+
+  m_speedMeter->setRange(static_cast<int>(std::floor(minValue)),
+                         static_cast<int>(std::ceil(maxValue)));
+  m_speedMeter->setValue(static_cast<int>(std::round(value)));
+  m_speedValueLabel->setText(
+    tr("%1  (range %2 .. %3)")
+      .arg(QString::number(value, 'f', 3))
+      .arg(QString::number(minValue, 'f', 2))
+      .arg(QString::number(maxValue, 'f', 2)));
+}
+
+void
+CFrmMeasurementView::refreshPercentDisplay(double value)
+{
+  if ((nullptr == m_percentBar) || (nullptr == m_percentValueLabel)) {
+    return;
+  }
+
+  const int percent = static_cast<int>(std::round(std::max(0.0, std::min(100.0, value))));
+  m_percentBar->setValue(percent);
+  m_percentValueLabel->setText(
+    tr("%1%  (raw %2)").arg(QString::number(percent)).arg(QString::number(value, 'f', 3)));
+}
+
+void
+CFrmMeasurementView::saveSamples()
+{
+  QString path = QFileDialog::getSaveFileName(this,
+                                              tr("Save measurement samples"),
+                                              "",
+                                              tr("CSV (*.csv);;All Files (*.*)"));
+  if (path.isEmpty()) {
+    return;
+  }
+
+  QFile file(path);
+  if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+    QMessageBox::warning(this,
+                         tr("Realtime Measurement"),
+                         tr("Unable to open '%1' for writing.").arg(path));
+    return;
+  }
+
+  QTextStream stream(&file);
+  stream << "timestamp_utc,value\n";
+  for (const auto& sample : m_samples) {
+    stream << sample.timestamp.toString(Qt::ISODateWithMs) << "," << QString::number(sample.value, 'f', 8)
+           << "\n";
+  }
+}
+
+void
+CFrmMeasurementView::clearSamples()
+{
+  m_samples.clear();
+  m_minSeen = 0;
+  m_maxSeen = 0;
+  refreshDisplay(0);
+}

--- a/src/cfrmmeasurementview.h
+++ b/src/cfrmmeasurementview.h
@@ -1,0 +1,124 @@
+// cfrmmeasurementview.h
+//
+// This file is part of the VSCP (https://www.vscp.org)
+//
+// The MIT License (MIT)
+//
+// Copyright (C) 2000-2026 Ake Hedman, Grodans Paradis AB
+// <info@grodansparadis.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+#ifndef CFRMMEASUREMENTVIEW_H
+#define CFRMMEASUREMENTVIEW_H
+
+#include <vscp.h>
+
+#include <QDateTime>
+#include <QWidget>
+
+#include <array>
+#include <vector>
+
+class QComboBox;
+class QLabel;
+class QDial;
+class QProgressBar;
+class QStackedWidget;
+class QPushButton;
+
+namespace QtCharts {
+class QLineSeries;
+class QChart;
+class QValueAxis;
+}
+
+struct CMeasurementSourceSpec {
+  uint16_t vscpClass{ 0 };
+  uint16_t vscpType{ 0 };
+  uint8_t sensorIndex{ 0 };
+  uint8_t unit{ 0 };
+  std::array<uint8_t, 16> guid{};
+
+  bool matches(const vscp_event_t* pev) const;
+};
+
+class CFrmMeasurementView : public QWidget {
+  Q_OBJECT
+
+public:
+  enum class displayMode { diagram = 0,
+                           value,
+                           speed_meter,
+                           percent };
+
+  struct measurementSample {
+    QDateTime timestamp;
+    double value{ 0 };
+  };
+
+  explicit CFrmMeasurementView(const CMeasurementSourceSpec& source,
+                               const QString& sourceDescription,
+                               QWidget* parent = nullptr);
+  ~CFrmMeasurementView();
+
+  bool matchesEvent(const vscp_event_t* pev) const;
+  void appendMeasurement(const vscp_event_t* pev);
+  const CMeasurementSourceSpec& getSource() const { return m_source; }
+
+private:
+  void setupUi();
+  void setDisplayMode(int index);
+  void refreshDisplay(double latestValue);
+  void refreshDiagram();
+  void refreshValueDisplay(double value);
+  void refreshSpeedMeterDisplay(double value);
+  void refreshPercentDisplay(double value);
+  void saveSamples();
+  void clearSamples();
+
+  static constexpr int MAX_SAMPLES = 500;
+
+  CMeasurementSourceSpec m_source;
+  QString m_sourceDescription;
+  std::vector<measurementSample> m_samples;
+  displayMode m_mode{ displayMode::diagram };
+  double m_minSeen{ 0 };
+  double m_maxSeen{ 0 };
+
+  QComboBox* m_modeCombo{ nullptr };
+  QLabel* m_sourceLabel{ nullptr };
+  QStackedWidget* m_displayStack{ nullptr };
+  QPushButton* m_saveButton{ nullptr };
+  QPushButton* m_clearButton{ nullptr };
+
+  QtCharts::QChart* m_chart{ nullptr };
+  QtCharts::QLineSeries* m_lineSeries{ nullptr };
+  QtCharts::QValueAxis* m_axisX{ nullptr };
+  QtCharts::QValueAxis* m_axisY{ nullptr };
+
+  QLabel* m_valueLabel{ nullptr };
+  QDial* m_speedMeter{ nullptr };
+  QLabel* m_speedValueLabel{ nullptr };
+  QProgressBar* m_percentBar{ nullptr };
+  QLabel* m_percentValueLabel{ nullptr };
+};
+
+#endif // CFRMMEASUREMENTVIEW_H

--- a/src/cfrmsession.cpp
+++ b/src/cfrmsession.cpp
@@ -60,6 +60,7 @@
 
 #include "cdlgmainsettings.h"
 #include "cdlgtxedit.h"
+#include "cfrmmeasurementview.h"
 
 #include <QClipboard>
 #include <QFile>
@@ -72,6 +73,9 @@
 #include <QToolButton>
 #include <QXmlStreamReader>
 #include <QtWidgets>
+
+#include <algorithm>
+#include <cstring>
 
 // ----------------------------------------------------------------------------
 
@@ -576,6 +580,10 @@ CFrmSession::createMenu()
 
   // * * * Tools menu * * *
   m_toolsMenu = new QMenu(tr("&Tools"), this);
+  m_openRealtimeMeasurementAct =
+    m_toolsMenu->addAction(tr("Open realtime measurement window..."),
+                           this,
+                           &CFrmSession::openRealtimeMeasurementWindow);
   m_menuBar->addMenu(m_toolsMenu);
 
   // Connections
@@ -2394,6 +2402,10 @@ CFrmSession::showRxContextMenu(const QPoint& pos)
                   this,
                   SLOT(setGuid()));
   menu->addSeparator();
+  menu->addAction(QString(tr("Open realtime measurement window...")),
+                  this,
+                  SLOT(openRealtimeMeasurementWindow()));
+  menu->addSeparator();
   menu->addAction(QString(tr("Add/Edit comment...")), this, SLOT(addEventNote()));
   menu->addAction(QString(tr("Remove comment")),
                   this,
@@ -2408,6 +2420,91 @@ CFrmSession::showRxContextMenu(const QPoint& pos)
                   SLOT(setVscpTypeMark()));
 
   menu->popup(m_rxTable->viewport()->mapToGlobal(pos));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// openRealtimeMeasurementWindow
+//
+
+void
+CFrmSession::openRealtimeMeasurementWindow(void)
+{
+  QModelIndexList selection = m_rxTable->selectionModel()->selectedRows();
+  if (!selection.size()) {
+    QMessageBox::information(this,
+                             tr(APPNAME),
+                             tr("Select a measurement row in the RX table first."),
+                             QMessageBox::Ok);
+    return;
+  }
+
+  const int row = selection.first().row();
+  vscp_event_t* pev = nullptr;
+  m_mutexRxList.lock();
+  if ((row >= 0) && (row < static_cast<int>(m_rxEvents.size()))) {
+    pev = m_rxEvents[row];
+  }
+  m_mutexRxList.unlock();
+
+  if ((nullptr == pev) || !vscp_isMeasurement(pev)) {
+    QMessageBox::information(this,
+                             tr(APPNAME),
+                             tr("The selected row does not contain a VSCP measurement event."),
+                             QMessageBox::Ok);
+    return;
+  }
+
+  CMeasurementSourceSpec source;
+  source.vscpClass   = pev->vscp_class;
+  source.vscpType    = pev->vscp_type;
+  source.sensorIndex = vscp_getMeasurementSensorIndex(pev);
+  source.unit        = vscp_getMeasurementUnit(pev);
+  memcpy(source.guid.data(), pev->GUID, 16);
+
+  std::string strGuid;
+  vscp_writeGuidArrayToString(strGuid, pev->GUID);
+
+  QString sourceDescription =
+    tr("Class=%1, Type=%2, Sensor=%3, Unit=%4, GUID=%5")
+      .arg(pev->vscp_class)
+      .arg(pev->vscp_type)
+      .arg(vscp_getMeasurementSensorIndex(pev))
+      .arg(vscp_getMeasurementUnit(pev))
+      .arg(strGuid.c_str());
+
+  CFrmMeasurementView* pview =
+    new CFrmMeasurementView(source, sourceDescription, this);
+  m_realtimeMeasurementViews.push_back(pview);
+
+  connect(pview, &QObject::destroyed, this, [this, pview]() {
+    m_realtimeMeasurementViews.erase(
+      std::remove(m_realtimeMeasurementViews.begin(),
+                  m_realtimeMeasurementViews.end(),
+                  pview),
+      m_realtimeMeasurementViews.end());
+  });
+
+  pview->appendMeasurement(pev);
+  pview->show();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// forwardMeasurementToRealtimeViews
+//
+
+void
+CFrmSession::forwardMeasurementToRealtimeViews(const vscp_event_t* pev)
+{
+  if (!vscp_isMeasurement(pev)) {
+    return;
+  }
+
+  for (auto* pview : m_realtimeMeasurementViews) {
+    if (nullptr == pview) {
+      continue;
+    }
+    pview->appendMeasurement(pev);
+  }
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4040,6 +4137,8 @@ CFrmSession::receiveRxRow(vscp_event_t* pev)
     cnt;
 
   m_mutexRxList.unlock();
+
+  forwardMeasurementToRealtimeViews(pev);
 
   // Fill unselected info
   fillReceiveEventCount();

--- a/src/cfrmsession.h
+++ b/src/cfrmsession.h
@@ -46,6 +46,7 @@
 #include <QToolButton>
 #include <QComboBox>
 #include <QMutex>
+#include <vector>
 
 QT_BEGIN_NAMESPACE
 class QAction;
@@ -66,6 +67,8 @@ class QTableWidgetItem;
 class QTableWidget;
 class QToolBox;
 QT_END_NAMESPACE
+
+class CFrmMeasurementView;
 
 // class CVscpClientCallback : public QObject
 // {
@@ -487,6 +490,9 @@ public slots:
   /// Open dialog to let user select retain publish topics to clear
   void openClearMqttRetainPublishTopics(void);
 
+  /// Open realtime visualization for selected measurement
+  void openRealtimeMeasurementWindow(void);
+
   /*!
       Timer slot: drain all available events from the client and route
       them through receiveCallback so the existing callback path is used.
@@ -517,6 +523,9 @@ private:
 
   /// Enable&disable receive filter
   void menu_filter_enable();
+
+  /// Push matching measurement events to open measurement windows
+  void forwardMeasurementToRealtimeViews(const vscp_event_t* pev);
 
   enum { NumGridRows = 8,
          NumButtons  = 4 };
@@ -646,6 +655,7 @@ private:
   // Settings menu
   QAction* m_setFilterAct;
   QAction* m_settingsAct;
+  QAction* m_openRealtimeMeasurementAct;
 
   QToolBar* m_txToolBar;
 
@@ -655,6 +665,8 @@ private:
   QAction* m_connectActBar;
   //QAction* m_connectActToolBar;
   QAction* m_setFilterActToolBar;
+
+  std::vector<CFrmMeasurementView*> m_realtimeMeasurementViews;
 };
 
 #endif // CFRMSESSION_H

--- a/vscpworks.pro
+++ b/vscpworks.pro
@@ -43,6 +43,7 @@ SOURCES +=  src/main.cpp \
     src/cdlgcanfilter.cpp \
     src/cdlgtls.cpp \
     src/cfrmsession.cpp \
+    src/cfrmmeasurementview.cpp \
     src/cfrmmqttexplorer.cpp \
     src/cfrmrawcansession.cpp \
     src/cfrmvscplinktest.cpp \
@@ -103,6 +104,7 @@ HEADERS  += src/vscpworks.h \
     src/cdlgcanfilter.h \
     src/cdlgtls.h \
     src/cfrmsession.h \
+    src/cfrmmeasurementview.h \
     src/cfrmmqttexplorer.h \
     src/cfrmrawcansession.h \
     src/cfrmvscplinktest.h \


### PR DESCRIPTION
## Summary
- add a dedicated realtime measurement window that can visualize one measurement source independently from the session window
- support configurable view modes: Diagram, Value, Speed meter and Percent
- route incoming measurement events to open measurement windows in realtime using source matching (class/type/guid/sensor/unit)
- add CSV save support for captured measurement samples
- add launch actions in the RX context menu and Tools menu
- wire new sources into both CMake and qmake build definitions

Fixes #11