### PR TITLE
Fix Linux CI for measurement view

### DIFF
--- a/src/cfrmmeasurementview.cpp
+++ b/src/cfrmmeasurementview.cpp
@@ -28,6 +28,8 @@
 
 #include "cfrmmeasurementview.h"
 
+#include <vscphelper.h>
+
 #include <QComboBox>
 #include <QDateTime>
 #include <QDial>
@@ -169,22 +171,22 @@ CFrmMeasurementView::setupUi()
   // Diagram page
   QWidget* pageDiagram    = new QWidget(this);
   QVBoxLayout* diagLayout = new QVBoxLayout(pageDiagram);
-  m_chart                 = new QtCharts::QChart();
+  m_chart                 = new QChart();
   m_chart->legend()->hide();
   m_chart->setTitle(tr("Measurement history"));
-  m_lineSeries = new QtCharts::QLineSeries();
+  m_lineSeries = new QLineSeries();
   m_chart->addSeries(m_lineSeries);
-  m_axisX = new QtCharts::QValueAxis();
+  m_axisX = new QValueAxis();
   m_axisX->setTitleText(tr("Sample"));
   m_axisX->setRange(0, MAX_SAMPLES);
   m_chart->addAxis(m_axisX, Qt::AlignBottom);
   m_lineSeries->attachAxis(m_axisX);
-  m_axisY = new QtCharts::QValueAxis();
+  m_axisY = new QValueAxis();
   m_axisY->setTitleText(tr("Value"));
   m_axisY->setRange(0, 100);
   m_chart->addAxis(m_axisY, Qt::AlignLeft);
   m_lineSeries->attachAxis(m_axisY);
-  QtCharts::QChartView* chartView = new QtCharts::QChartView(m_chart, pageDiagram);
+  QChartView* chartView = new QChartView(m_chart, pageDiagram);
   chartView->setRenderHint(QPainter::Antialiasing);
   diagLayout->addWidget(chartView);
   m_displayStack->addWidget(pageDiagram);

--- a/src/cfrmmeasurementview.h
+++ b/src/cfrmmeasurementview.h
@@ -43,12 +43,9 @@ class QDial;
 class QProgressBar;
 class QStackedWidget;
 class QPushButton;
-
-namespace QtCharts {
 class QLineSeries;
 class QChart;
 class QValueAxis;
-}
 
 struct CMeasurementSourceSpec {
   uint16_t vscpClass{ 0 };
@@ -109,10 +106,10 @@ private:
   QPushButton* m_saveButton{ nullptr };
   QPushButton* m_clearButton{ nullptr };
 
-  QtCharts::QChart* m_chart{ nullptr };
-  QtCharts::QLineSeries* m_lineSeries{ nullptr };
-  QtCharts::QValueAxis* m_axisX{ nullptr };
-  QtCharts::QValueAxis* m_axisY{ nullptr };
+  QChart* m_chart{ nullptr };
+  QLineSeries* m_lineSeries{ nullptr };
+  QValueAxis* m_axisX{ nullptr };
+  QValueAxis* m_axisY{ nullptr };
 
   QLabel* m_valueLabel{ nullptr };
   QDial* m_speedMeter{ nullptr };


### PR DESCRIPTION
## Summary
- add missing `#include <vscphelper.h>` in `src/cfrmmeasurementview.cpp` so VSCP measurement helper declarations are visible
- align Qt Charts type usage with Qt6 by using global `QChart`, `QLineSeries`, `QValueAxis`, and `QChartView` types instead of `QtCharts::` qualified names

This fixes the Linux compile failures reported on `master` for `cfrmmeasurementview.cpp`.
