### PR TITLE
Fix QtCharts forward declarations in cfrmmeasurementview.h

### DIFF
--- a/src/cfrmmeasurementview.h
+++ b/src/cfrmmeasurementview.h
@@ -43,9 +43,11 @@ class QDial;
 class QProgressBar;
 class QStackedWidget;
 class QPushButton;
+namespace QtCharts {
 class QLineSeries;
 class QChart;
 class QValueAxis;
+}
 
 struct CMeasurementSourceSpec {
   uint16_t vscpClass{ 0 };
@@ -106,10 +108,10 @@ private:
   QPushButton* m_saveButton{ nullptr };
   QPushButton* m_clearButton{ nullptr };
 
-  QChart* m_chart{ nullptr };
-  QLineSeries* m_lineSeries{ nullptr };
-  QValueAxis* m_axisX{ nullptr };
-  QValueAxis* m_axisY{ nullptr };
+  QtCharts::QChart* m_chart{ nullptr };
+  QtCharts::QLineSeries* m_lineSeries{ nullptr };
+  QtCharts::QValueAxis* m_axisX{ nullptr };
+  QtCharts::QValueAxis* m_axisY{ nullptr };
 
   QLabel* m_valueLabel{ nullptr };
   QDial* m_speedMeter{ nullptr };


### PR DESCRIPTION
Linux CI was failing because `QChart`, `QLineSeries`, and `QValueAxis` were forward-declared in global namespace, while the `.cpp` file uses them as `QtCharts::QChart` etc.

Fixes:
- Wrap the three forward declarations inside `namespace QtCharts { ... }`
- Update member variable types to use `QtCharts::` prefix to match

This resolves the compile errors:
- `invalid use of incomplete type 'class QtCharts::QChart'`
- `'QChartView' is not a member of 'QtCharts'`