### PR TITLE
Fix QtCharts namespace in cfrmmeasurementview.h (Windows/Linux CI)

### DIFF
--- a/src/cfrmmeasurementview.h
+++ b/src/cfrmmeasurementview.h
@@ -43,9 +43,11 @@ class QDial;
 class QProgressBar;
 class QStackedWidget;
 class QPushButton;
+namespace QtCharts {
 class QLineSeries;
 class QChart;
 class QValueAxis;
+}
 
 struct CMeasurementSourceSpec {
   uint16_t vscpClass{ 0 };
@@ -106,10 +108,10 @@ private:
   QPushButton* m_saveButton{ nullptr };
   QPushButton* m_clearButton{ nullptr };
 
-  QChart* m_chart{ nullptr };
-  QLineSeries* m_lineSeries{ nullptr };
-  QValueAxis* m_axisX{ nullptr };
-  QValueAxis* m_axisY{ nullptr };
+  QtCharts::QChart* m_chart{ nullptr };
+  QtCharts::QLineSeries* m_lineSeries{ nullptr };
+  QtCharts::QValueAxis* m_axisX{ nullptr };
+  QtCharts::QValueAxis* m_axisY{ nullptr };
 
   QLabel* m_valueLabel{ nullptr };
   QDial* m_speedMeter{ nullptr };


### PR DESCRIPTION
Follow-up to #54. The `.cpp` `#include <vscphelper.h>` fix was merged, but the header still forward-declares `QChart`, `QLineSeries`, `QValueAxis` in **global** namespace while the `.cpp` uses them as `QtCharts::` types — causing MSVC C2027 (undefined type) on Windows.

**Changes:**
- Wrap three forward declarations inside `namespace QtCharts { ... }`  
- Update member variable types to `QtCharts::QChart*`, `QtCharts::QLineSeries*`, `QtCharts::QValueAxis*`