### PR TITLE
fix: Qt6-compatible CDATA token type in parseXmlElement

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -189,9 +189,11 @@ parseXmlElement(QXmlStreamReader& reader)
         return json();
       }
     }
-    else if ((QXmlStreamReader::Characters == token ||
-              QXmlStreamReader::CDATA == token) &&
-             !reader.isWhitespace()) {
+    else if ((QXmlStreamReader::Characters == token
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+              || QXmlStreamReader::CDATA == token
+#endif
+             ) && !reader.isWhitespace()) {
       text += reader.text().toString();
     }
     else if (QXmlStreamReader::EndElement == token) {


### PR DESCRIPTION
## Problem

CI was failing on master with:

```
error: 'CDATA' is not a member of 'QXmlStreamReader'
```

Qt6 removed `QXmlStreamReader::CDATA` as a distinct `TokenType` enum value. CDATA sections are now reported as `Characters` tokens (and can be identified with `reader.isCDATA()` if needed).

## Fix

Added a preprocessor version guard around the now-removed Qt5-only `CDATA` enum case in `parseXmlElement()`:

```cpp
- else if ((QXmlStreamReader::Characters == token ||
-           QXmlStreamReader::CDATA == token) &&
-          !reader.isWhitespace()) {
+ else if ((QXmlStreamReader::Characters == token
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+           || QXmlStreamReader::CDATA == token
+#endif
+          ) && !reader.isWhitespace()) {
```

- **Qt6**: Only the `Characters` branch applies — correct, because Qt6 reports CDATA as `Characters`.
- **Qt5**: Both `Characters` and `CDATA` branches apply — preserves existing behavior exactly.

No logic change on either platform; purely a compilation fix.