### PR TITLE
Fix Qt6 CI blockers: QtCharts namespace and QAction slot mismatch

### DIFF
--- a/src/cfrmmeasurementview.h
+++ b/src/cfrmmeasurementview.h
@@ -43,11 +43,9 @@ class QDial;
 class QProgressBar;
 class QStackedWidget;
 class QPushButton;
-namespace QtCharts {
 class QLineSeries;
 class QChart;
 class QValueAxis;
-}
 
 struct CMeasurementSourceSpec {
   uint16_t vscpClass{ 0 };
@@ -108,10 +106,10 @@ private:
   QPushButton* m_saveButton{ nullptr };
   QPushButton* m_clearButton{ nullptr };
 
-  QtCharts::QChart* m_chart{ nullptr };
-  QtCharts::QLineSeries* m_lineSeries{ nullptr };
-  QtCharts::QValueAxis* m_axisX{ nullptr };
-  QtCharts::QValueAxis* m_axisY{ nullptr };
+  QChart* m_chart{ nullptr };
+  QLineSeries* m_lineSeries{ nullptr };
+  QValueAxis* m_axisX{ nullptr };
+  QValueAxis* m_axisY{ nullptr };
 
   QLabel* m_valueLabel{ nullptr };
   QDial* m_speedMeter{ nullptr };

--- a/src/cfrmsession.cpp
+++ b/src/cfrmsession.cpp
@@ -329,7 +329,7 @@ CFrmSession::createMenu()
   m_exportSessionAct = m_fileMenu->addAction(QIcon::fromTheme("document-save-as"),
                                              tr("Export session to file..."),
                                              this,
-                                             &CFrmSession::saveSessionToFile);
+                                             &CFrmSession::saveSessionToFileAct);
 
   m_loadTxAct =
     m_fileMenu->addAction(QIcon::fromTheme("document-open"),


### PR DESCRIPTION
## Summary

Fixes two remaining Qt6 build failures on Linux/macOS/Windows after PR #60.

### 1. `cfrmmeasurementview.h` — QtCharts namespace removed in Qt6

**Problem:** The header forward-declared `QChart`, `QLineSeries`, and `QValueAxis` inside `namespace QtCharts { … }` and used `QtCharts::` as the member-variable types. In Qt6 the `QtCharts` namespace was eliminated — the classes live directly in the global namespace. This caused the compiler to see the forward-declared `QtCharts::QChart` as an incomplete type that is *different* from the actual `::QChart` constructed in the `.cpp`, producing "incompatible pointer" and "incomplete type" errors.

**Fix:** Replaced the namespaced forward declarations with plain global ones (`class QChart;` etc.) and changed the three member-variable types from `QtCharts::QChart*` → `QChart*`, etc. The `.cpp` already used unqualified names and required no change.

### 2. `cfrmsession.cpp` — `QAction::triggered(bool)` connected to `saveSessionToFile(const QString&)`

**Problem:** `createMenus()` called `m_fileMenu->addAction(…, this, &CFrmSession::saveSessionToFile)`. The `addAction` overload internally connects `QAction::triggered(bool)` to the supplied callable; `saveSessionToFile` takes `const QString& path = ""`, which is not convertible from `bool`. Qt6's new-style slot machinery rejects the mismatch at compile time with `no matching function for call to makeCallableObject<void (QAction::*)(bool)>(void (CFrmSession::*)(const QString&))`.

**Fix:** Changed the slot pointer to `&CFrmSession::saveSessionToFileAct`, the existing `void` wrapper defined in the header (`void saveSessionToFileAct(void) { saveSessionToFile(); }`), which is fully compatible with `triggered(bool)`.