### PR TITLE
Fix remaining Qt6 compile blockers (cfrmmeasurementview + cfrmsession)

### DIFF
--- a/src/cfrmmeasurementview.h
+++ b/src/cfrmmeasurementview.h
@@ -43,11 +43,9 @@ class QDial;
 class QProgressBar;
 class QStackedWidget;
 class QPushButton;
-namespace QtCharts {
-class QLineSeries;
 class QChart;
+class QLineSeries;
 class QValueAxis;
-}
 
 struct CMeasurementSourceSpec {
   uint16_t vscpClass{ 0 };
@@ -108,10 +106,10 @@ private:
   QPushButton* m_saveButton{ nullptr };
   QPushButton* m_clearButton{ nullptr };
 
-  QtCharts::QChart* m_chart{ nullptr };
-  QtCharts::QLineSeries* m_lineSeries{ nullptr };
-  QtCharts::QValueAxis* m_axisX{ nullptr };
-  QtCharts::QValueAxis* m_axisY{ nullptr };
+  QChart* m_chart{ nullptr };
+  QLineSeries* m_lineSeries{ nullptr };
+  QValueAxis* m_axisX{ nullptr };
+  QValueAxis* m_axisY{ nullptr };
 
   QLabel* m_valueLabel{ nullptr };
   QDial* m_speedMeter{ nullptr };

--- a/src/cfrmsession.cpp
+++ b/src/cfrmsession.cpp
@@ -329,7 +329,7 @@ CFrmSession::createMenu()
   m_exportSessionAct = m_fileMenu->addAction(QIcon::fromTheme("document-save-as"),
                                              tr("Export session to file..."),
                                              this,
-                                             &CFrmSession::saveSessionToFile);
+                                             &CFrmSession::saveSessionToFileAct);
 
   m_loadTxAct =
     m_fileMenu->addAction(QIcon::fromTheme("document-open"),


### PR DESCRIPTION
## Summary

Fixes two remaining Qt6 compile failures reported on master (commit 144e352).

### Fix 1 — `cfrmmeasurementview.h`: wrong namespace for QtCharts forward declarations

In Qt 6, `QChart`, `QLineSeries`, `QValueAxis`, and `QChartView` are in the **global namespace** (`QT_BEGIN_NAMESPACE` expands to nothing when `QT_NAMESPACE` is not set). The header was wrapping the forward declarations in `namespace QtCharts {}`, creating `QtCharts::QChart` as a distinct (incomplete) type that was incompatible with the global `QChart` provided by `<QtCharts/QChart>`.

**Changes:**
- Remove the `namespace QtCharts {}` wrapper from the forward declarations
- Change member types from `QtCharts::QChart*` / `QtCharts::QLineSeries*` / `QtCharts::QValueAxis*` to unqualified `QChart*` / `QLineSeries*` / `QValueAxis*`

### Fix 2 — `cfrmsession.cpp`: signal/slot signature mismatch

`QMenu::addAction(...)` with a member-function slot internally connects `QAction::triggered(bool)` to the provided callable. The code was passing `&CFrmSession::saveSessionToFile` whose signature is `void(const QString& path = "")` — a `bool`→`const QString&` mismatch that Qt6's `makeCallableObject` rejects at compile time.

**Change:**
- Use `&CFrmSession::saveSessionToFileAct` instead — the existing no-arg wrapper slot (`void saveSessionToFileAct() { saveSessionToFile(); }`) that was already present in the header, consistent with the `loadSessionFromFileAct` pattern used everywhere else in the same function.

## Testing

Both files compile cleanly against Qt 6.11.1 on Linux (verified by direct `c++` invocation with the same flags CMake uses for this project).