### PR TITLE
Fix Windows build: add missing pch.h guard to cfrmmeasurementview.cpp

### DIFF
--- a/src/cfrmmeasurementview.cpp
+++ b/src/cfrmmeasurementview.cpp
@@ -26,6 +26,10 @@
 // SOFTWARE.
 //
 
+#ifdef WIN32
+#include <pch.h>
+#endif
+
 #include "cfrmmeasurementview.h"
 
 #include <vscphelper.h>


### PR DESCRIPTION
Fixes the remaining Windows x64 build failure (pre-existing before PR #61).

cfrmmeasurementview.cpp was missing the `#ifdef WIN32 / #include <pch.h>` guard used by every other .cpp in the project. Without it, vscp.h pulls in Windows networking headers before the PCH sets the correct include order, causing 'inaddr.h: s_b1 unknown override specifier' and dozens of downstream macro/struct errors.