### PR TITLE
fix: Windows winsock2 include order in cfrmmeasurementview.cpp

### DIFF
--- a/src/cfrmmeasurementview.cpp
+++ b/src/cfrmmeasurementview.cpp
@@ -26,6 +26,14 @@
 // SOFTWARE.
 //
 
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+
+#ifdef WIN32
+#include <pch.h>
+#endif
+
 #include "cfrmmeasurementview.h"
 
 #include <vscphelper.h>


### PR DESCRIPTION
## Problem

`cfrmmeasurementview.cpp` was missing the Windows precompiled header include that all other VSCP source files use. Without it, Qt's headers pull in `windows.h` first, which drags in the old `winsock.h`. Then `vscphelper.h → sockettcp.h → ws2def.h` conflicts with the already-loaded socket definitions, producing a cascade of C3646/C2143 errors in `ws2def.h` and `winsock2.h`.

## Fix

Add the standard project pattern at the top of the file (matching `vscpworks.cpp`, `cfrmsession.cpp`, etc.):
```cpp
#ifndef WIN32_LEAN_AND_MEAN
#define WIN32_LEAN_AND_MEAN
#endif
#ifdef WIN32
#include <pch.h>
#endif
```

`pch.h` includes `<winsock2.h>` before `<windows.h>`, establishing the correct include order and preventing the conflict.