### PR TITLE
fix: restore cross-platform CI build in cfrmmdf regex

### DIFF
--- a/src/cfrmmdf.cpp
+++ b/src/cfrmmdf.cpp
@@ -221,7 +221,7 @@ normalizeSavedXmlDateFields(const QString& path)
   QString content        = originalContent;
   QString updatedContent = content;
   int delta              = 0;
-  const QRegularExpression attrDateRe(R"(date\s*=\s*"([^"]*)")");
+  const QRegularExpression attrDateRe(R"re(date\s*=\s*"([^"]*)")re");
   auto attrIt = attrDateRe.globalMatch(content);
   while (attrIt.hasNext()) {
     const QRegularExpressionMatch match = attrIt.next();


### PR DESCRIPTION
## Summary

Fixes the current cross-platform compile failure in `src/cfrmmdf.cpp` caused by a malformed raw string literal in `normalizeSavedXmlDateFields()`.

### Root cause
`attrDateRe` used a raw-string delimiter that collides with the regex content and terminates the string early, so compilers report a missing terminating quote and fail the build.

### Fix
Switched to a custom raw-string delimiter so the regex literal parses correctly while preserving the intended pattern:

- from `R"(date\s*=\s*"([^"]*)")"`
- to `R"re(date\s*=\s*"([^"]*)")re"`

This is a no-behavior-change parser fix that restores compilation on Linux/macOS/Windows toolchains.