### PR TITLE
Add arm64 Linux CI build

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -11,8 +11,13 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-24.04, ubuntu-latest]
+        include:
+          - os: ubuntu-24.04
+            qt_arch: linux_gcc_64
+          - os: ubuntu-24.04-arm
+            qt_arch: linux_gcc_arm64
 
     steps:
 
@@ -23,7 +28,7 @@ jobs:
         version: 6.11.1
         host: 'linux'
         target: 'desktop'
-        arch: 'linux_gcc_64'
+        arch: ${{ matrix.qt_arch }}
         modules: 'qtcharts qtconnectivity qtserialbus qtserialport qtwebsockets'
 
       # https://github.com/actions/checkout


### PR DESCRIPTION
This PR adds ARM64 coverage to the Linux GitHub Actions workflow so builds can run on 64-bit Raspberry Pi-style runners.

The workflow now uses a matrix with two Linux targets:
- `ubuntu-24.04` with `linux_gcc_64`
- `ubuntu-24.04-arm` with `linux_gcc_arm64`

This keeps the existing x86_64 build path intact while enabling CI for arm64 environments.

Testing:
- Reviewed the updated workflow YAML and confirmed the new matrix targets the expected Qt architectures.